### PR TITLE
docs: audit P1/P2 corrections + docs-layout-archon-style sweep

### DIFF
--- a/.claude/rules/karpathy.md
+++ b/.claude/rules/karpathy.md
@@ -1,0 +1,41 @@
+# Karpathy Guidelines — Coding Discipline
+
+Derived from Andrej Karpathy's observations on common LLM coding pitfalls. These run alongside all other project rules — not optional, not situational.
+
+## 1. Think Before Coding
+
+State assumptions explicitly before implementing. If multiple interpretations exist, present them — don't pick silently. If something is unclear, stop and ask. Push back when a simpler approach exists.
+
+## 2. Simplicity First
+
+Minimum code that solves the problem. Nothing speculative.
+
+- No features beyond what was asked
+- No abstractions for single-use code
+- No "flexibility" that wasn't requested
+- No error handling for impossible scenarios
+
+AgentAuth has 5 direct dependencies by design. Every abstraction is a candidate to reject. If a change balloons a function, stop and reconsider.
+
+## 3. Surgical Changes
+
+Touch only what you must. Clean up only your own mess.
+
+- Don't improve adjacent code, comments, or formatting
+- Don't refactor things that aren't broken
+- Match existing style, even if you'd do it differently
+- If you notice unrelated issues — note them in TECH-DEBT.md, don't fix them inline
+
+**This is especially critical in `authz/`, `token/`, and `revoke/`.** Small "improvements" to adjacent security code introduce subtle regressions that tests don't catch because the behavior change wasn't the stated goal.
+
+Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+Define success criteria before starting. Loop until verified.
+
+- "Fix the bug" → write a story that reproduces it, run against the binary, record evidence, then mark PASS
+- "Add validation" → write tests for invalid inputs, then make them pass
+- For multi-step tasks, state a brief plan with a verify step per item
+
+Weak criteria ("make it work") require constant clarification. Strong criteria let you loop independently.

--- a/.plans/bugs/BUG-CLI-002-awrit-init-config-path.md
+++ b/.plans/bugs/BUG-CLI-002-awrit-init-config-path.md
@@ -1,0 +1,129 @@
+# BUG-CLI-002 — `awrit init` writes config to wrong path
+
+**ID:** BUG-CLI-002  
+**Severity:** HIGH  
+**Introduced in:** commit `4e197a5` (`fix(cli): rename aactl binary to awrit (TD-CLI-001)`)  
+**Linked TD:** TD-CLI-002  
+**Status:** Open — fix branch not yet created
+
+---
+
+## Summary
+
+`awrit init` writes the generated config file to `~/.agentauth/config`. The broker's
+config auto-loader reads from `~/.broker/config`. These paths do not match. A user
+who runs `awrit init` without `--config-path` ends up with a config file the broker
+silently ignores, causing the broker to start with no admin secret and exit with a FATAL.
+
+---
+
+## Root Cause
+
+Two commits touched the same logical concern but were not reconciled:
+
+| Commit | File | What it did |
+|--------|------|-------------|
+| `07daa20` (TD-CFG-002) | `internal/cfg/configfile.go` | Updated broker auto-load search paths: `/etc/agentauth/config` → `/etc/broker/config`, `~/.agentauth/config` → `~/.broker/config` |
+| `4e197a5` (TD-CLI-001) | `cmd/awrit/init_cmd.go` | Created `resolveConfigPath()` with the **old paths**: `/etc/agentauth/config` and `~/.agentauth/config` |
+
+`07daa20` landed first. `4e197a5` was created after it, but introduced new code using
+the stale paths — they were never synced.
+
+---
+
+## Affected Code
+
+**File:** `cmd/awrit/init_cmd.go`  
+**Function:** `resolveConfigPath()` (lines 53–64)
+
+```go
+func resolveConfigPath() string {
+    if initConfigPath != "" {
+        return initConfigPath
+    }
+    if p := os.Getenv("AA_CONFIG_PATH"); p != "" {
+        return p
+    }
+    home, err := os.UserHomeDir()
+    if err != nil {
+        return "/etc/agentauth/config"   // ← should be /etc/broker/config
+    }
+    return home + "/.agentauth/config"  // ← should be /.broker/config
+}
+```
+
+**Broker reads from** (`internal/cfg/configfile.go:24`):
+```go
+locs = append(locs, filepath.Join(home, ".broker", "config"))
+```
+
+---
+
+## Impact
+
+A user following the getting-started guide:
+
+1. Runs `awrit init` → config written to `~/.agentauth/config`
+2. Starts broker → broker searches `~/.broker/config`, finds nothing
+3. `AA_ADMIN_SECRET` is unset → broker exits FATAL: `admin secret required`
+
+The `--config-path` flag works around this, but no getting-started doc tells users
+they need it because the default is supposed to Just Work.
+
+---
+
+## Fix
+
+**File:** `cmd/awrit/init_cmd.go:53–64`
+
+```go
+func resolveConfigPath() string {
+    if initConfigPath != "" {
+        return initConfigPath
+    }
+    if p := os.Getenv("AA_CONFIG_PATH"); p != "" {
+        return p
+    }
+    home, err := os.UserHomeDir()
+    if err != nil {
+        return "/etc/broker/config"
+    }
+    return home + "/.broker/config"
+}
+```
+
+Two literal changes. No other files affected.
+
+---
+
+## Verification
+
+After the fix, run:
+
+```bash
+# Build
+go build -o bin/awrit ./cmd/awrit
+
+# Run init
+./bin/awrit init --mode dev
+
+# Confirm path
+ls -la ~/.broker/config           # must exist
+cat ~/.broker/config              # must contain ADMIN_SECRET=...
+
+# Start broker (reads ~/.broker/config automatically)
+./bin/broker
+# Expect: broker starts, no FATAL on admin secret
+```
+
+Unit test: `internal/cfg/configfile_test.go` already tests that `~/.broker/config`
+is in the search path. Add a test in `cmd/awrit/init_cmd_test.go` (or similar)
+that calls `resolveConfigPath()` with `HOME` set and asserts the returned path
+ends in `.broker/config`.
+
+---
+
+## Branch
+
+`fix/td-cli-002-awrit-init-config-path` off `develop`  
+Needs: code fix + unit test + `./scripts/gates.sh task` green + PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Docs audit P1/P2 corrections (2026-04-12)
+
+- **`docs/getting-started-user.md`** — admin auth examples used the literal `"my-secret-key-change-in-production"` while the guide starts the broker with a randomly generated `$AA_ADMIN_SECRET`. Examples now reference `$AA_ADMIN_SECRET` so the first-run path works without 401s.
+- **`docs/awrit-reference.md`** — `awrit init` sample output showed `~/.agentwrit/config`; corrected to `~/.broker/config` (the actual default write path — or rather, the broker's read path; see TD-CLI-002 for the underlying code bug).
+- **`docs/api.md`** — JWT claims table corrected: `iss` is driven by `AA_ISSUER` (empty by default, issuer validation skipped); app token subject is `app:{internal_app_id}` not `app:{client_id}`; `aud` is driven by `AA_AUDIENCE` (omitted if unset, audience validation skipped).
+- **`docs/getting-started-operator.md`** — `AA_AUDIENCE` default corrected from `"agentwrit"` to *(empty)*. SQLite persistence note corrected: setting `AA_DB_PATH=""` does not enable memory-only mode — unset uses the `./data.db` default.
+- **`docs/api/openapi.yaml`** — `info.license` corrected from `Apache-2.0` to `AGPL-3.0` with the correct license URL. Matches `LICENSE`, `README.md`, and `CLA.md`.
+- **`docker-compose.yml`** — Docker bridge network renamed `agentauth-net` → `agentwrit-net` to match brand sweep and operator docs.
+- **`docs/README.md`** — API reference entry corrected from "22 HTTP endpoints" to "19". Concepts entry corrected from "seven components" to "eight".
+- **`docs/concepts.md`** — intro sentence corrected from "seven components" to "eight".
+- **`TECH-DEBT.md`** — added TD-CLI-002 (HIGH: `awrit init` writes to `~/.agentauth/config`, broker reads `~/.broker/config` — broken first-run path introduced in commit `4e197a5`) and TD-CLI-003 (Low: docker-compose.yml network name lag). Bug report at `.plans/bugs/BUG-CLI-002-awrit-init-config-path.md`.
+
 ### Renamed CLI binary `aactl` → `awrit` (TD-CLI-001)
 
 - **`cmd/aactl/` → `cmd/awrit/`** — directory renamed. Cobra command name changed (`Use: "aactl"` → `Use: "awrit"`). All internal CLI output, help text, and error messages updated.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@
 - `.claude/rules/testing.md` — LIVE test and acceptance test expectations
 - `.claude/rules/golang.md` — Go coding standards
 - `.claude/rules/mandatory-reading.md` — **Read this entirely and summarize it back to the user at session start.** Defines what goes in MEMORY.md vs FLOW.md vs TECH-DEBT.md. Do NOT mix them up.
+- `.claude/rules/karpathy.md` — coding discipline (simplicity, surgical changes, goal-driven execution). Always active alongside the rules above.
 
 ## Defaults
 

--- a/FLOW.md
+++ b/FLOW.md
@@ -532,3 +532,37 @@ Rewrote the AgentWrit public intro copy for the rebrand (Layer 1 of Decision 013
 
 ### Status: Copy ready — apply on next agentauth-core session
 **Next:** apply the new intro to the website, core README, and any other location the old intro lives. Single source of truth in the decision file — no per-repo drift.
+
+---
+
+## 2026-04-12 — Docs audit P1/P2 corrections + TD-CLI-002 bug discovery
+
+### Action: Fixed 9 doc accuracy issues from external audit report
+
+Branch: `doc/docs-layout-archon-style`
+
+Audit report surfaced P1/P2 findings against the codebase. After verification:
+
+**Docs fixed (pure doc errors — no code changes):**
+- `docs/getting-started-user.md` — wrong admin secret literal in auth examples → `$AA_ADMIN_SECRET`
+- `docs/awrit-reference.md` — `awrit init` sample output showed `~/.agentwrit/config` → `~/.broker/config`
+- `docs/api.md` — JWT claims table: `iss` not always "agentwrit" (driven by `AA_ISSUER`, empty by default); app subject is `app:{internal_app_id}` not `app:{client_id}`; `aud` driven by `AA_AUDIENCE`, omitted if unset
+- `docs/getting-started-operator.md` — `AA_AUDIENCE` default was wrong (`"agentwrit"` → empty); SQLite memory-mode fallback claim removed (false — empty `AA_DB_PATH` falls back to `./data.db`)
+- `docs/api/openapi.yaml` — license `Apache-2.0` → `AGPL-3.0`
+- `docker-compose.yml` — network `agentauth-net` → `agentwrit-net` (brand sweep miss)
+- `docs/README.md` — endpoint count 22 → 19 (verified from route registration); component count seven → eight
+- `docs/concepts.md` — component count seven → eight
+
+**Left alone (intentional code/docs gap — code-side rebrand not done yet):**
+- `urn:agentauth:error:` in `internal/problemdetails/problemdetails.go` — docs say `urn:agentwrit:error:`, code hasn't been renamed; this is planned work
+- `agentauth_*` metric names in `internal/obs/obs.go` — docs say `agentwrit_*`, same situation
+
+**New tech debt logged:**
+- TD-CLI-002 (HIGH) — `awrit init` writes to `~/.agentauth/config`, broker reads `~/.broker/config`. Bug introduced in `4e197a5`: TD-CFG-002 fixed the broker read side but the CLI write side (`cmd/awrit/init_cmd.go:53-64`) was created with old paths. Bug report: `.plans/bugs/BUG-CLI-002-awrit-init-config-path.md`
+- TD-CLI-003 (Low) — docker-compose.yml network name lag (fixed in this session)
+
+### What's Next
+
+1. **`fix/td-cli-002-awrit-init-config-path`** — two-line fix in `cmd/awrit/init_cmd.go:53-64`, unit test, gates, PR. Bug report ready at `.plans/bugs/BUG-CLI-002-awrit-init-config-path.md`.
+2. **Code-side rebrand** — rename `agentauth_*` Prometheus metrics in `internal/obs/obs.go` and `urn:agentauth:error:` in `internal/problemdetails/problemdetails.go` to match the docs. Separate PR.
+3. **Merge `doc/docs-layout-archon-style`** — after user review.

--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -77,6 +77,7 @@ B0 removed all sidecar Go code and infrastructure but did NOT rewrite the user-f
 | TD-012 | **MISSING: Role model documentation — who does what, which scopes, and why** | **CRITICAL** | `docs/` — new file needed | See detail below. Without this document, every agent that touches the code misunderstands the system. |
 | TD-013 | `POST /v1/admin/launch-tokens` lets admin CREATE agents — admin should only LIST/REVOKE launch tokens | High | `cmd/broker/main.go:257`, `internal/admin/admin_hdl.go:58-60` | See detail below. |
 | TD-014 | **Code comments audit — all handlers, services, and types need role/scope/boundary comments** | **CRITICAL** | All `internal/` packages | Every function, handler, and type must document: what it does, who can call it (role/scope), why it exists, and its boundaries. Current code has minimal Go doc comments that describe mechanics but not roles, scopes, or security boundaries. An agent reading only the source file cannot understand who calls what or why. Standard defined in `.claude/rules/golang.md`. |
+| TD-015 | `deleg_svc.go` comment says "strict subset" but `ScopeIsSubset` allows equal scopes | Low | `internal/deleg/deleg_svc.go:10-11` | Line 10 says "The delegated scope must be a strict subset of the delegator's scope" but the actual `ScopeIsSubset` check allows equal scopes (subset-or-equal). The behavior is correct — the comment is wrong. Fix: change "strict subset" to "subset" in the package doc. |
 
 ### TD-012 Detail: Missing Role Model Document
 
@@ -351,6 +352,21 @@ Audit triggered by discovery of hardcoded `iss: "agentauth"` in `internal/token/
 | TD-CLI-001 | ~~**Binary name `aactl` → `awrit` rename**~~ | ~~MEDIUM~~ | **RESOLVED 2026-04-10** — `cmd/aactl/` → `cmd/awrit/`, `docs/aactl-reference.md` → `docs/awrit-reference.md`, Cobra command `Use` field, all ship-to-main doc/script/test/config references rewritten. Evidence files under `tests/*/evidence/*.md` preserved as-is (historical records). Branch `fix/td-cli-001-aactl-to-awrit-rename`. | `cmd/awrit/`, `docs/awrit-reference.md`, scripts, docs, tests |
 
 **Not creating a TD for env var prefix** — decided 2026-04-10 to keep `AA_*` indefinitely. Neutral enough (two letters), operator-facing, highest-friction change in the whole rebrand. Re-evaluate at 1.0 if ever.
+
+| TD-CLI-002 | **`awrit init` writes config to `~/.agentauth/config` but broker reads `~/.broker/config`** — broken first-run path | **HIGH** | Immediate — breaks first-run UX | `cmd/awrit/init_cmd.go:53-64` |
+| TD-CLI-003 | **`docker-compose.yml` network still named `agentauth-net`** — docs say `agentwrit-net` after brand sweep | Low | Next compose-touching PR | `docker-compose.yml:35,42` |
+
+### TD-CLI-002 Detail: awrit init config path mismatch
+
+TD-CFG-002 (resolved 2026-04-10) updated `internal/cfg/configfile.go` to search `~/.broker/config` and `/etc/broker/config`. But commit `4e197a5` (TD-CLI-001, awrit rename) introduced `cmd/awrit/init_cmd.go` with `resolveConfigPath()` still returning `~/.agentauth/config` (home) and `/etc/agentauth/config` (fallback). The fix to the broker's *read* side and the creation of the CLI's *write* side happened in different commits and were never reconciled.
+
+**Impact:** A user who runs `awrit init` (no `--config-path`) gets a config at `~/.agentauth/config`. The broker auto-loads from `~/.broker/config`. The config is silently ignored and the broker starts with no admin secret, causing a `FATAL` exit.
+
+**Fix:** In `cmd/awrit/init_cmd.go:53-64`, update `resolveConfigPath()`:
+- `"/etc/agentauth/config"` → `"/etc/broker/config"`
+- `home + "/.agentauth/config"` → `home + "/.broker/config"`
+
+**Needs:** `fix/td-cli-002-awrit-init-config-path` branch + gates + PR. Bug report at `.plans/bugs/BUG-CLI-002-awrit-init-config-path.md`.
 
 ## When to Fix
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,12 +32,12 @@ services:
       timeout: 3s
       retries: 10
     networks:
-      - agentauth-net
+      - agentwrit-net
 
 
 volumes:
   broker-data:
 
 networks:
-  agentauth-net:
+  agentwrit-net:
     driver: bridge

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,86 @@
+# AgentWrit Documentation
+
+AgentWrit is an open-source credential broker for AI agents. It issues short-lived, scope-attenuated tokens so agents operate with only the permissions their task requires — nothing more, nothing longer.
+
+---
+
+## The Book of AgentWrit
+
+Start here. These pages explain what AgentWrit is, why it exists, and how every piece fits together.
+
+| Page | What you'll learn |
+|------|-------------------|
+| [What Is AgentWrit?](agentwrit-explained.md) | The problem, the solution, and the three token types — no prior knowledge required |
+| [Foundations](foundations.md) | What tokens are, why they beat API keys, and how JWTs work under the hood |
+| [The Three Actors](roles.md) | Operator, Application, Agent — who holds what token and why |
+| [Scopes and Permissions](scope-model.md) | The `action:resource:identifier` format, coverage rules, and the four enforcement points |
+| [The Credential Lifecycle](credential-model.md) | Every credential's claims, TTLs, and how they flow through the attenuation chain |
+| [Design Decisions](design-decisions.md) | Why we chose JWTs, Ed25519, SPIFFE, hash-chained audit, and everything else |
+
+---
+
+## Getting Started
+
+Hands-on guides for each persona. Pick the one that matches your role.
+
+| If you are... | Start here |
+|---------------|-----------|
+| **Just trying AgentWrit** to see how it works | [Your First Five Minutes](getting-started-user.md) |
+| **Building an AI agent** in Python, TypeScript, or Go | [Getting Started: Developer](getting-started-developer.md) |
+| **Deploying AgentWrit** in production | [Getting Started: Operator](getting-started-operator.md) |
+
+---
+
+## Guides
+
+Deeper walkthroughs for specific tasks and patterns.
+
+| Guide | What it covers |
+|-------|---------------|
+| [Common Tasks](common-tasks.md) | Token renewal, delegation, revocation, audit queries — the everyday operations |
+| [Integration Patterns](integration-patterns.md) | Resource server validation, multi-agent orchestration, cloud federation |
+| [Scenarios](scenarios.md) | End-to-end walkthroughs: data pipeline agent, customer service bot, CI/CD runner |
+| [Troubleshooting](troubleshooting.md) | Common errors, what causes them, and how to fix them |
+
+---
+
+## Reference
+
+Lookup documentation for endpoints, CLI commands, and internals.
+
+| Reference | What it covers |
+|-----------|---------------|
+| [API Reference](api.md) | All 19 HTTP endpoints — request/response formats, error codes, rate limits |
+| [CLI Reference (awrit)](awrit-reference.md) | Every `awrit` command with examples and output formats |
+| [Architecture](architecture.md) | Internal package map, component diagrams, data flow |
+| [Implementation Map](implementation-map.md) | Where every feature lives in the codebase — file paths, function names, test locations |
+| [Concepts Deep Dive](concepts.md) | The full security pattern, industry context, and all eight components |
+
+---
+
+## Live Demos
+
+See AgentWrit in action with the [Python SDK](https://github.com/devonartis/agentauth-python) demo applications:
+
+| Demo | What it shows |
+|------|-------------|
+| **[MedAssist AI](https://github.com/devonartis/agentauth-python/tree/main/demo)** | Healthcare multi-agent pipeline — clinical, prescription, and billing agents operating under strict scope isolation with LLM tool-calling, delegation, and per-patient scoping |
+| **[Support Ticket Zero-Trust](https://github.com/devonartis/agentauth-python/tree/main/demo2)** | Three LLM-driven agents processing support tickets with broker-issued scoped credentials, streaming execution via SSE, and natural token expiry |
+
+Both demos run against a real AgentWrit broker and show the full credential lifecycle: agent registration, scope enforcement, delegation, renewal, release, and revocation.
+
+---
+
+## Reading Order
+
+If you're new, this path gets you productive fastest:
+
+```
+What Is AgentWrit?  →  Your First Five Minutes  →  Pick your persona guide
+        ↓                                                    ↓
+   Foundations  →  The Three Actors  →  Scopes  →  Common Tasks
+```
+
+If you're evaluating AgentWrit for your organization, start with [What Is AgentWrit?](agentwrit-explained.md) — it's written for people who aren't deeply technical.
+
+If you're a security reviewer, start with [Concepts Deep Dive](concepts.md) and [Architecture](architecture.md).

--- a/docs/agentwrit-explained.md
+++ b/docs/agentwrit-explained.md
@@ -1,164 +1,174 @@
-# AgentWrit Explained
+# What Is AgentWrit?
 
-> For sales teams and developers new to the system. No prior knowledge of JWTs or cryptography required.
-
----
-
-## The Problem
-
-AI agents need credentials to do their work — read a database, call an API, write to a log. Most systems give those agents a long-lived API key that has broad access and never expires. When that key leaks — through a breach, an accident, a compromised vendor — the damage is wide and the fix is painful.
-
-AgentWrit replaces long-lived keys with short-lived, task-scoped tokens that expire automatically, can be revoked instantly, and can only do what they were specifically created for.
+AgentWrit is a credential broker for AI agents. It issues short-lived, task-scoped tokens so agents operate with only the permissions their task requires — nothing more, nothing longer.
 
 ---
 
-## What a Token Is in This System
+## The Problem: Credentials That Don't Match the Work
 
-A token is a digitally signed string. When a caller makes a request to the broker, they put the token in the HTTP request header:
+AI agents are different from the services that traditional credentials were designed for. Some agents spin up in seconds, finish a task in two minutes, and die. Others run for hours processing a batch pipeline. Some are one-shot — do a thing and exit. Others are long-running orchestrators that spawn sub-agents throughout the day.
 
-```
-Authorization: Bearer <token>
-```
+What they have in common: **their credential lifetime has no relationship to their task lifetime.** A two-minute agent holds a permanent API key. A four-hour pipeline holds the same permanent API key. Neither agent needs access after its work is done, but the credential doesn't know that — it stays valid indefinitely.
 
-The broker reads that header, verifies the token's signature, checks it hasn't been revoked, then checks whether it carries the scope required for that specific endpoint. If any check fails, the request is rejected with a 401 or 403. If all checks pass, the request proceeds.
+Now multiply that by fifty agents, all sharing the same key. You can't tell which agent did what. You can't revoke one without killing all fifty. And when one is compromised, you can't surgically remove it — you have to rotate the shared key, which means every service and agent that depends on it stops working until you reconfigure all of them. That's not rotating a credential. That's an outage.
 
-This is how both the admin token and the app token work. Same mechanism. What separates them is what is embedded inside — specifically their **scopes**.
+The root problem isn't carelessness. It's a mismatch: traditional credentials assume long-lived services with predictable, stable identities. AI agents — whether they run for minutes or hours — break that assumption because they're dynamic, task-specific, and numerous. The credential model needs to match the work model.
 
 ---
 
-## The Admin Token — The Root of the System
+## The Solution: Ephemeral, Scoped Tokens
 
-The admin token is where everything starts. Nothing else in the system can exist without it.
+AgentWrit replaces long-lived keys with short-lived, task-scoped tokens. Each token expires on a configurable TTL (five minutes by default, adjustable up to 24 hours for longer pipelines), carries only the permissions its task requires, and can be revoked individually — the revocation takes effect on the very next request any resource server validates against the broker.
 
-**How it's obtained:**
-```
-POST /v1/admin/auth
-{ "secret": "..." }
-```
+Think of it like a building access system — not the master key kind, but the kind where every contractor gets a badge programmed for specific floors, specific doors, and a specific time window. The badge expires when the job is done. If one contractor's badge is compromised, security deactivates that badge without reprogramming every other contractor in the building.
 
-The operator sends the master admin secret. The broker verifies it against a bcrypt hash — the plaintext secret is never stored. If it matches, the broker issues a signed JWT that lasts **5 minutes**.
+AgentWrit works the same way for AI agents:
 
-**What scopes it carries:**
-```
-admin:launch-tokens:*
-admin:revoke:*
-admin:audit:*
-```
-
-**What each scope does:**
-
-`admin:launch-tokens:*` — this scope opens two things. First, it lets the admin register, update, and deregister applications. When an application is registered, the admin sets its **scope ceiling** — the maximum permissions any agent running under that app can ever receive. Second, it lets the admin create launch tokens directly, which is the bootstrap path before any apps exist.
-
-`admin:revoke:*` — this scope is the kill switch. The admin can cancel any token, any agent, any task, or an entire delegation chain. No other token type can do this.
-
-`admin:audit:*` — this scope gives the admin full visibility into the audit trail. Every credential issued, every failed attempt, every scope violation — all of it. No other token type can see the full trail.
-
-**Why 5 minutes:** The admin token is the most powerful credential in the system. Keeping it short-lived limits the window of exposure if it's intercepted. The operator authenticates, does what they need to do, and the token expires.
+| Traditional API Keys | AgentWrit Tokens |
+|---------------------|-----------------|
+| Permanent until rotated | Expire on a configurable TTL (default: 5 min) |
+| Shared across agents | Unique per agent instance |
+| Broad permissions | Scoped to specific actions on specific resources |
+| Revoke one = rotate the shared key = outage | Revoke one agent, others keep working |
+| "service-account-prod did something" | "agent `spiffe://acme.co/agent/orch-456/task-789/a1b2c3d4` read `customers`" |
 
 ---
 
-## The App Token — Bounded Authority
+## The Three Core Concepts
 
-Once the admin has registered an application and set its scope ceiling, the application authenticates with its own credentials to get its own token. This is the production path for creating agents.
+Everything in AgentWrit builds on three ideas:
 
-**How it's obtained:**
+| Concept | What It Is | Think of It Like |
+|---------|-----------|-----------------|
+| **Scopes** | Permission strings in the format `action:resource:identifier` that say exactly what a token holder can do | A badge that reads "Floor 3 only, read-only access" |
+| **Launch Tokens** | Single-use, 30-second registration passes that authorize one agent to join the system | A one-time visitor pass at the lobby desk |
+| **The Attenuation Chain** | Each credential in the system can never *exceed* the one that created it — same scope or narrower, never wider | Each person can hand out keys to the same rooms they have access to or fewer, never more |
+
+Here's how they connect — the **attenuation chain**:
+
+```mermaid
+flowchart TB
+    SECRET["🔑 Admin Secret<br/><i>Root of trust — never travels, never expires</i>"]
+    ADMIN["🛡️ Admin Token<br/><i>5 min · admin:* scopes</i>"]
+    APP["📦 App Token<br/><i>30 min · app:* scopes</i>"]
+    LAUNCH["🎫 Launch Token<br/><i>30 sec · single-use</i>"]
+    AGENT["🤖 Agent Token<br/><i>Task TTL · task-specific scopes</i>"]
+    DELEG["🔗 Delegated Token<br/><i>Narrower scope · max 5 levels</i>"]
+
+    SECRET -->|"authenticates"| ADMIN
+    ADMIN -->|"registers app<br/>sets scope ceiling"| APP
+    APP -->|"creates launch token<br/>ceiling enforced ✓"| LAUNCH
+    LAUNCH -->|"agent registers<br/>proves key ownership"| AGENT
+    AGENT -->|"delegates<br/>scope can never expand"| DELEG
+
+    classDef root fill:#1a1a2e,stroke:#e94560,color:#fff,stroke-width:2px
+    classDef admin fill:#16213e,stroke:#0f3460,color:#fff
+    classDef app fill:#0f3460,stroke:#53a8b6,color:#fff
+    classDef launch fill:#533483,stroke:#e94560,color:#fff
+    classDef agent fill:#2b4865,stroke:#256d85,color:#fff
+    classDef deleg fill:#334756,stroke:#548ca8,color:#fff
+
+    class SECRET root
+    class ADMIN admin
+    class APP app
+    class LAUNCH launch
+    class AGENT agent
+    class DELEG deleg
 ```
-POST /v1/app/auth
-{ "client_id": "...", "client_secret": "..." }
-```
 
-The `client_id` and `client_secret` were generated when the admin registered the app. The secret is shown once at registration and never stored in plaintext — only a bcrypt hash is persisted.
-
-**What scopes it carries:**
-```
-app:launch-tokens:*
-app:agents:*
-app:audit:read
-```
-
-**What each scope does:**
-
-`app:launch-tokens:*` — lets the app create launch tokens for its agents. Every launch token created through this path is checked against the app's scope ceiling. If the requested scope exceeds the ceiling, the broker rejects it with a 403 and records the violation in the audit trail.
-
-`app:agents:*` — reserved for agent management operations.
-
-`app:audit:read` — reserved for the app reading its own audit events, scoped to its agents only.
-
-**What it cannot do:** call any admin endpoint. The scope strings are different. An app token carrying `app:launch-tokens:*` cannot open a route that requires `admin:launch-tokens:*`. The broker enforces this on every request.
-
-**Why the app token exists as a separate credential from the admin token:** The admin token is for a human or a deployment script. It's short-lived and powerful. The app token is for software running autonomously in production — an orchestrator, a pipeline, a backend service. It lives longer (30 minutes, configurable), authenticates differently (client_id/secret rather than a master secret), and is bounded by a ceiling the admin defined. If the app's credentials are compromised, the attacker can only create agents within that ceiling. They cannot revoke tokens, cannot read the full audit trail, cannot touch other apps.
+At every step, authority can never expand. The admin defines what apps can do. Apps define what agents can do. Agents define what sub-agents can do. A delegate can receive the same scope as its delegator or less — but never more.
 
 ---
 
-## The Scope — What Actually Controls Access
+## How It Works in Practice
 
-The scope is a string in the format `action:resource:identifier`. Examples:
+The full flow from zero to a working agent takes six steps:
 
+```mermaid
+sequenceDiagram
+    actor Operator
+    participant Broker
+    participant App as App (Software)
+    participant Agent as AI Agent
+    participant RS as Resource Server
+
+    rect rgb(30, 40, 60)
+        Note over Operator,Broker: Phase 1: Bootstrap (one-time setup)
+        Operator->>Broker: 1. POST /v1/admin/auth {secret}
+        Broker-->>Operator: Admin JWT (5 min)
+        Operator->>Broker: 2. POST /v1/admin/apps {ceiling: ["read:data:*"]}
+        Broker-->>Operator: client_id + client_secret
+    end
+
+    rect rgb(20, 50, 50)
+        Note over App,Broker: Phase 2: Production (automated)
+        App->>Broker: 3. POST /v1/app/auth {client_id, secret}
+        Broker-->>App: App JWT (30 min)
+        App->>Broker: 4. POST /v1/app/launch-tokens {scope}
+        Note right of Broker: Ceiling check ✓
+        Broker-->>App: Launch token (30s, single-use)
+    end
+
+    rect rgb(40, 30, 60)
+        Note over Agent,RS: Phase 3: Agent work
+        App-->>Agent: Deliver launch token
+        Agent->>Broker: 5. GET /v1/challenge → sign nonce → POST /v1/register
+        Broker-->>Agent: Agent JWT (task TTL)
+        Agent->>RS: 6. Bearer token → do work
+        RS->>Broker: POST /v1/token/validate
+        Broker-->>RS: Valid ✓ scopes: ["read:data:*"]
+    end
 ```
-admin:revoke:*        — admin can revoke anything
-app:launch-tokens:*   — app can create launch tokens
-read:data:customers   — agent can read customer data
-write:logs:run-42     — agent can write to a specific log
-```
 
-When a request arrives, the broker middleware calls `RequireScope` — it checks whether the token's scopes cover the required scope for that endpoint. If not, 403. The scope is not advisory. It is enforced in code on every single request.
-
-The ceiling works the same way. When an app creates a launch token, the broker calls `ScopeIsSubset` — it checks whether every requested scope is covered by the app's ceiling. If the app tries to request a scope it doesn't hold, the request is denied before the launch token is created.
+The admin token appears at steps 1 and 2 — then it expires and leaves the picture. From step 3 onward, the app manages its own agents autonomously. The admin's decision at step 2 — the scope ceiling — controls what is possible from that point forward.
 
 ---
 
-## The Launch Token — A Different Kind of Token
+## What AgentWrit Is NOT
 
-The launch token is not a JWT. It is a random 64-character hex string — 32 bytes of cryptographic randomness encoded as hex. It has no structure, no signature to verify, no claims to read. It is looked up from the database when presented.
+Before you go further, a few things AgentWrit explicitly does not do:
 
-```
-a3f9c2d1e8b74f0a...  (64 hex characters)
-```
+**Not an OAuth provider.** OAuth is designed for user-delegated access ("let this app access my Google Drive"). AgentWrit handles machine-to-machine credentialing with no user in the loop.
 
-It has one job: give a specific agent one opportunity to register. By default it expires in **30 seconds** and can only be used **once**. After it is consumed at registration, it is marked in the database and cannot be used again.
+**Not a secrets manager.** AgentWrit issues credentials. It doesn't store your database passwords or API keys. It gives agents a scoped identity so downstream services can verify them.
 
-The launch token carries a policy — the scope the agent is allowed to request and the maximum TTL its credential can have. The agent cannot exceed either.
+**Not a service mesh.** No sidecars, no proxies. AgentWrit is a standalone broker that issues and validates tokens over HTTP.
 
 ---
 
-## The Agent Credential — Task-Scoped, Traceable
-
-When the agent presents the launch token at `POST /v1/register`, it also proves it controls its own cryptographic key by signing a challenge the broker issued. If the launch token is valid and the signature checks out, the broker issues an Agent JWT.
-
-The Agent JWT carries:
-- The exact scopes the agent requested (within the launch token's policy)
-- A SPIFFE-format identity that encodes the orchestrator, task, and instance — making every agent credential traceable to the exact task that created it
-- A unique token ID so it can be cancelled individually
-
-The agent uses this JWT as a Bearer token — the same `Authorization: Bearer <token>` header — when calling downstream services, which validate it at `POST /v1/token/validate`.
-
----
-
-## How It All Connects
-
-```
-1. Admin authenticates        → gets Admin JWT (5 min, admin:* scopes)
-2. Admin registers App        → sets scope ceiling, gets client_id + client_secret
-3. App authenticates          → gets App JWT (30 min, app:* scopes)
-4. App creates launch token   → ceiling enforced, 30s expiry, single-use
-5. Launch token sent to agent → via environment variable or orchestrator config
-6. Agent requests challenge   → signs it with its own key
-7. Agent registers            → presents launch token + signed challenge → gets Agent JWT
-8. Agent does its work        → uses Agent JWT as Bearer token
-9. Admin can revoke anything  → at any level, any time, takes effect immediately
-```
-
-The admin token appears at steps 1 and 2 — then it expires and leaves the picture. From step 3 onward the app manages its own agents autonomously. The admin's decision at step 2 — the scope ceiling — controls what is possible from that point forward, enforced by the broker on every request.
-
----
-
-## For Sales: The Three Questions You'll Get
+## Frequently Asked Questions
 
 **"How is this different from API keys?"**
-API keys are permanent, usually over-permissioned, and require a full rotation when one leaks. AgentWrit credentials expire on their own, are scoped to a specific task, and can be cancelled in seconds without affecting anything else running at the same time.
+API keys are permanent, usually over-permissioned, and shared across multiple agents — so when one leaks, you rotate the key and take down every agent that depends on it. AgentWrit tokens expire on a configurable TTL, are scoped to a specific task, and can be revoked individually. The revocation takes effect on the next request. No rotation, no collateral damage.
 
 **"What if an agent is compromised?"**
-The admin revokes it. One call to `POST /v1/revoke` cancels the specific token, the specific agent, the specific task, or the entire delegation chain — whatever the situation requires. The revocation takes effect on the next request. No key rotation, no downtime for other agents.
+The operator revokes it. One API call cancels the specific token, the specific agent, all agents on a task, or an entire delegation chain — four levels of surgical revocation, matched to the blast radius. Every subsequent validation request for the revoked credential is rejected. No key rotation, no downtime for other agents.
 
 **"Can a developer give an agent more access than they should?"**
 No. The platform team sets the scope ceiling when registering the application. When the developer's code requests a launch token, the broker checks every requested scope against that ceiling. If any scope exceeds it, the request is rejected before the launch token is created.
+
+---
+
+## What's Next?
+
+Ready to see it in action? Start here:
+
+**[Your First Five Minutes →](getting-started-user.md)**
+Run a local setup with Docker, walk through the registration flow, and get your first agent token.
+
+**[Live Demos →](https://github.com/devonartis/agentauth-python)**
+See AgentWrit in real applications — a healthcare multi-agent pipeline and a support ticket zero-trust demo, both running against a live broker with LLM-driven agents.
+
+Or jump to the topic that matches your interest:
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| Understand what tokens actually are and how JWTs work | [Foundations](foundations.md) |
+| See who holds which token and why | [The Three Actors](roles.md) |
+| Learn the permission system | [Scopes and Permissions](scope-model.md) |
+| Integrate AgentWrit into your agent code | [Getting Started: Developer](getting-started-developer.md) |
+| Deploy AgentWrit in production | [Getting Started: Operator](getting-started-operator.md) |
+
+---
+
+*Previous: [Documentation Home](README.md) · Next: [Your First Five Minutes](getting-started-user.md)*

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,12 +1,6 @@
 # API Reference
 
-> **Document Version:** 3.0 | **Last Updated:** March 2026 | **Status:** Current
->
-> **Audience:** Developers and operators who need the definitive contract for every endpoint.
->
-> **Prerequisites:** [Concepts](concepts.md) for background, [Getting Started: Developer](getting-started-developer.md) or [Getting Started: Operator](getting-started-operator.md) for walkthroughs.
->
-> **Next steps:** [Troubleshooting](troubleshooting.md) for error resolution | [Common Tasks](common-tasks.md) for step-by-step workflows.
+Complete HTTP API specification for all endpoints.
 
 ---
 
@@ -38,6 +32,21 @@ All responses include security headers: `X-Content-Type-Options: nosniff`, `Cach
 Request bodies are limited to 1 MB on ALL endpoints (enforced by global middleware).
 
 **Error sanitization:** Token validation, renewal, and auth middleware endpoints return generic error messages (e.g., `"token is invalid or expired"`, `"token renewal failed"`, `"token verification failed"`) to prevent leaking internal details to clients.
+
+---
+
+## Rate Limiting
+
+Authentication endpoints are rate-limited to protect against brute-force attacks.
+
+| Endpoint | Rate | Burst | Key | Retry-After |
+|----------|------|-------|-----|-------------|
+| `POST /v1/admin/auth` | 5 req/s | 10 | Per IP address | 1 second |
+| `POST /v1/app/auth` | Configurable | Configurable | Per `client_id` (falls back to IP) | 60 seconds |
+
+When a rate limit is exceeded, the broker returns `429 Too Many Requests` in RFC 7807 Problem Details format with a `Retry-After` header.
+
+**Production note:** The broker extracts client IP from the `X-Forwarded-For` header. In production, always place the broker behind a reverse proxy that overwrites this header — otherwise clients can spoof their IP to bypass rate limits.
 
 ---
 
@@ -1045,7 +1054,7 @@ A `*` in the identifier position of an allowed scope covers any specific identif
 
 ### Attenuation
 
-Scopes can only narrow, never expand. This is enforced at two points:
+Scopes can never expand — same or narrower, never wider. This is enforced at two points:
 
 1. **Registration:** `requested_scope` must be a subset of `launch_token.allowed_scope`
 2. **Delegation:** `delegated_scope` must be a subset of `delegator.scope`
@@ -1060,9 +1069,9 @@ All tokens issued by AgentWrit use EdDSA (Ed25519) signing with compact JWT seri
 
 | Field | JSON Key | Type | Description |
 |---|---|---|---|
-| `Iss` | `iss` | string | Always `"agentwrit"` |
-| `Sub` | `sub` | string | SPIFFE agent ID, `"admin"`, or `"app:{client_id}"` |
-| `Aud` | `aud` | string[] | Audience (optional) |
+| `Iss` | `iss` | string | Value of `AA_ISSUER`; empty string if unset (issuer validation skipped) |
+| `Sub` | `sub` | string | SPIFFE agent ID, `"admin"`, or `"app:{internal_app_id}"` |
+| `Aud` | `aud` | string[] | Value of `AA_AUDIENCE`; omitted if unset (audience validation skipped) |
 | `Exp` | `exp` | int64 | Expiration timestamp (Unix seconds) |
 | `Nbf` | `nbf` | int64 | Not-before timestamp (Unix seconds) |
 | `Iat` | `iat` | int64 | Issued-at timestamp (Unix seconds) |
@@ -1129,3 +1138,17 @@ Applied to `POST /v1/admin/auth` and `POST /v1/app/auth`:
 | `agentwrit_active_agents` | Gauge | -- | Currently registered agents |
 | `agentwrit_request_duration_seconds` | HistogramVec | `endpoint` | Request latency |
 | `agentwrit_clock_skew_total` | Counter | -- | Clock skew events |
+
+---
+
+## What's Next?
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| Use the operator CLI instead | [CLI Reference (awrit)](awrit-reference.md) |
+| See the internal architecture | [Architecture](architecture.md) |
+| Find where features live in code | [Implementation Map](implementation-map.md) |
+
+---
+
+*Previous: [Troubleshooting](troubleshooting.md) · Next: [CLI Reference (awrit)](awrit-reference.md)*

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -9,8 +9,8 @@ info:
   contact:
     name: AgentWrit
   license:
-    name: Apache-2.0
-    url: https://www.apache.org/licenses/LICENSE-2.0
+    name: AGPL-3.0
+    url: https://www.gnu.org/licenses/agpl-3.0.html
 
 servers:
   - url: http://localhost:8080

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,12 +1,8 @@
-# Architecture
+# Architecture — How AgentWrit Works Inside
 
-> **Document Version:** 3.0 | **Last Updated:** March 2026 | **Status:** Current
->
-> **Audience:** Contributors, security reviewers, and operators who want to understand how AgentWrit works internally.
->
-> **Prerequisites:** [Concepts](concepts.md) for the security pattern overview.
->
-> **Next steps:** [API Reference](api.md) | [Contributing](../CONTRIBUTING.md) | [Getting Started: Operator](getting-started-operator.md)
+Two binaries, one Go module, fourteen internal packages. This page shows how every component connects — from HTTP request to signed JWT to audit record.
+
+**Prerequisites:** [Concepts](concepts.md) helps, but isn't required.
 
 ---
 
@@ -431,7 +427,7 @@ flowchart LR
 
 2. **Persistent Ed25519 signing key.** On first startup, the broker generates an Ed25519 key pair via `crypto/rand` and writes it to `AA_SIGNING_KEY_PATH` (default `./signing.key`) in PKCS8 PEM format with `0600` permissions. On subsequent startups, the existing key is loaded from disk. Tokens remain valid across restarts as long as the key file persists. Delete the key file to force key rotation (all previously issued tokens become unverifiable). See `internal/keystore` for implementation.
 
-3. **Scope attenuation is one-way.** Scopes can only narrow, never expand. Enforced at registration (requested scope vs. launch token ceiling), delegation (delegated vs. delegator scope), and app-authenticated launch-token creation (requested `allowed_scope` vs. app ceiling).
+3. **Scope attenuation is one-way.** Scopes can never expand — same or narrower, never wider. Enforced at registration (requested scope vs. launch token ceiling), delegation (delegated vs. delegator scope), and app-authenticated launch-token creation (requested `allowed_scope` vs. app ceiling).
 
 4. **Scope check before launch token consumption.** At registration, `ScopeIsSubset` is called before `ConsumeLaunchToken`. A scope violation returns an error without wasting a single-use token.
 
@@ -471,3 +467,88 @@ These are explicit trust boundaries and limitations of the current implementatio
 | Go stdlib `crypto/sha256` | -- | Audit hash chain, delegation chain hash |
 | Go stdlib `net/http` | -- | HTTP server (Go 1.22+ method routing) |
 | `golang.org/x/crypto/bcrypt` | v0.48.0 | Admin secret hash verification |
+
+---
+
+## Background Maintenance
+
+The broker runs two background tasks on a 60-second ticker:
+
+**JTI Pruning** (`store.PruneExpiredJTIs`) — Removes expired JWT ID entries from the database. JTIs are stored to prevent token replay; once a token expires, its JTI is no longer needed. The pruner keeps the database from growing unbounded.
+
+**Agent Expiration** (`store.ExpireAgents`) — Marks agents as expired when they exceed inactivity thresholds. This catches agents that crashed without calling `POST /v1/token/release` to self-revoke.
+
+Both tasks log their results at the `Ok` level with the operation name and count of affected records.
+
+---
+
+## Mutual Authentication Protocol
+
+The `mutauth` package provides agent-to-agent mutual authentication using a three-step cryptographic handshake. This is currently a Go API only — HTTP exposure is planned for a future release.
+
+### The Three-Step Handshake
+
+```mermaid
+sequenceDiagram
+    participant A as Agent A (Initiator)
+    participant Broker
+    participant B as Agent B (Responder)
+
+    rect rgb(30, 40, 60)
+        Note over A,Broker: Step 1: Initiate
+        A->>Broker: InitiateHandshake(myToken, targetAgentID)
+        Broker->>Broker: Verify A's token ✓<br/>Confirm B exists ✓<br/>Generate nonce
+        Broker-->>A: nonce
+    end
+
+    rect rgb(20, 50, 50)
+        Note over A,B: Step 2: Respond
+        A->>B: "Here's the nonce. Prove you're agent B."
+        B->>B: Verify A's token/identity ✓<br/>Sign nonce with Ed25519 key
+        B-->>A: signed_nonce + counter_nonce
+    end
+
+    rect rgb(40, 30, 60)
+        Note over A,Broker: Step 3: Complete
+        A->>Broker: CompleteHandshake(B's signed nonce)
+        Broker->>Broker: Look up B's public key<br/>Verify nonce signature ✓
+        Broker-->>A: Mutual auth verified ✓
+    end
+```
+
+### Discovery Registry
+
+The `DiscoveryRegistry` maps agent SPIFFE IDs to network endpoints so agents can find each other:
+
+| Operation | What it does |
+|-----------|-------------|
+| `Bind(agentID, endpoint)` | Associates an agent's SPIFFE ID with a reachable endpoint |
+| `Resolve(agentID)` | Looks up the endpoint for a given agent ID |
+| `Unbind(agentID)` | Removes an agent's endpoint binding |
+| `VerifyBinding(agentID, presentedID)` | Identity-consistency check during handshakes |
+
+### Heartbeat Manager
+
+The `HeartbeatMgr` tracks agent liveness with periodic heartbeats (default: 30-second interval, max 3 consecutive misses). When an agent exceeds the miss threshold, the heartbeat manager can optionally auto-revoke the agent's credentials via `revoke.RevSvc`.
+
+---
+
+## What's Next?
+
+You've seen how the pieces fit together. Pick your next step:
+
+**[API Reference →](api.md)**
+Every endpoint — request formats, response shapes, error codes, and rate limits.
+
+Or explore related topics:
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| Find where a feature lives in the code | [Implementation Map](implementation-map.md) |
+| Use the operator CLI | [CLI Reference (awrit)](awrit-reference.md) |
+| Deploy in production | [Getting Started: Operator](getting-started-operator.md) |
+| Understand the security pattern | [Concepts Deep Dive](concepts.md) |
+
+---
+
+*Previous: [Concepts](concepts.md) · Next: [API Reference](api.md)*

--- a/docs/awrit-reference.md
+++ b/docs/awrit-reference.md
@@ -1,12 +1,6 @@
 # awrit CLI Reference
 
-> **Document Version:** 3.0 | **Last Updated:** March 2026 | **Status:** Current
->
-> **Audience:** Operators and administrators managing the AgentWrit broker.
->
-> **Prerequisites:** [Getting Started: Operator](getting-started-operator.md) for initial setup, [Concepts](concepts.md) for background on agents, tokens, and scopes.
->
-> **Next steps:** [Common Tasks](common-tasks.md) for step-by-step workflows | [Troubleshooting](troubleshooting.md) for error resolution.
+The operator command-line tool for managing tokens, apps, revocation, and audit trails.
 
 ---
 
@@ -692,7 +686,7 @@ Use the generated secret to set `AACTL_ADMIN_SECRET` for subsequent awrit comman
 **Output:**
 
 ```
-Config written to: /home/user/.agentwrit/config
+Config written to: /home/user/.broker/config
 
 Admin secret: dGVzdC1zZWNyZXQtdmFsdWUtYmFzZTY0LWVuY29kZWQtdGV4dA...
 
@@ -1069,3 +1063,17 @@ A: Use cron or systemd timer to run:
    ```bash
    awrit audit events --limit 10000 --json > "/backups/audit-$(date +%Y-%m-%d).json"
    ```
+
+---
+
+## What's Next?
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| Look up HTTP endpoints | [API Reference](api.md) |
+| See the internal architecture | [Architecture](architecture.md) |
+| Find where features live in code | [Implementation Map](implementation-map.md) |
+
+---
+
+*Previous: [API Reference](api.md) · Next: [Architecture](architecture.md)*

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -2,12 +2,6 @@
 
 Step-by-step instructions for AgentWrit workflows, organized by role.
 
-**Document metadata:**
-- **Audience:** Developers (building AI agents), Platform Operators (managing AgentWrit deployments)
-- **Version:** 2.0.0
-- **Prerequisites:** Broker running. See [Getting Started: Developer](getting-started-developer.md) or [Getting Started: Operator](getting-started-operator.md).
-- **Next steps:** For advanced topics, see [Concepts](concepts.md), [API Reference](api.md), [Architecture](architecture.md), or [Troubleshooting](troubleshooting.md).
-
 ---
 
 ## Quick Reference
@@ -672,9 +666,9 @@ else:
 
 ### Delegate a Token to Another Agent
 
-Delegation lets your agent issue a narrower-scoped token to another registered agent. Scopes can only narrow (attenuate), never expand.
+Delegation lets your agent issue a token to another registered agent with the same scope or less. Scopes can never expand — the delegate can receive your full scope, but never exceed it.
 
-**What's happening:** Delegation creates a new token signed by the broker, with a reference back to your token in the delegation chain. This allows you to hand off work to a less-privileged agent without exposing your full token. The chain is cryptographically verified; each entry must narrow the scope further.
+**What's happening:** Delegation creates a new token signed by the broker, with a reference back to your token in the delegation chain. This allows you to hand off work to another agent without exposing your full token. The chain is cryptographically verified; each entry's scope must be covered by the delegator's scope.
 
 **Python example:**
 
@@ -1536,16 +1530,30 @@ except ValueError as e:
 
 **Revocation decision tree:**
 
-```
-What happened?
-├─ Single token leaked
-│  └─ Token-level revocation (target = JTI)
-├─ Agent instance compromised
-│  └─ Agent-level revocation (target = SPIFFE ID)
-├─ Entire task suspect
-│  └─ Task-level revocation (target = task_id)
-└─ Delegation chain exploited
-   └─ Chain-level revocation (target = root delegator SPIFFE ID)
+```mermaid
+flowchart TD
+    Q{"What happened?"}
+    T1["Single token leaked"]
+    T2["Agent instance compromised"]
+    T3["Entire task suspect"]
+    T4["Delegation chain exploited"]
+    R1["Token-level revocation<br/><i>target = JTI</i>"]
+    R2["Agent-level revocation<br/><i>target = SPIFFE ID</i>"]
+    R3["Task-level revocation<br/><i>target = task_id</i>"]
+    R4["Chain-level revocation<br/><i>target = root delegator SPIFFE ID</i>"]
+
+    Q --> T1 --> R1
+    Q --> T2 --> R2
+    Q --> T3 --> R3
+    Q --> T4 --> R4
+
+    classDef question fill:#533483,stroke:#e94560,color:#fff,stroke-width:2px
+    classDef scenario fill:#16213e,stroke:#0f3460,color:#fff
+    classDef action fill:#0f3460,stroke:#53a8b6,color:#fff
+
+    class Q question
+    class T1,T2,T3,T4 scenario
+    class R1,R2,R3,R4 action
 ```
 
 **If revocation fails:**
@@ -2277,3 +2285,18 @@ AgentWrit uses RFC 7807 `application/problem+json` error responses.
 - **Concepts:** [concepts.md](concepts.md) — SPIFFE, token lifetime, delegation, scopes
 - **Architecture:** [architecture.md](architecture.md) — Broker, key management, trust model
 - **Troubleshooting:** [troubleshooting.md](troubleshooting.md) — Common problems and solutions
+
+---
+
+## What's Next?
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| See end-to-end usage scenarios | [Scenarios](scenarios.md) |
+| Integrate with resource servers and orchestrators | [Integration Patterns](integration-patterns.md) |
+| Debug issues | [Troubleshooting](troubleshooting.md) |
+| Look up endpoints | [API Reference](api.md) |
+
+---
+
+*Previous: [Getting Started: Operator](getting-started-operator.md) · Next: [Integration Patterns](integration-patterns.md)*

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,14 +1,6 @@
-# Concepts: Why AgentWrit Exists
+# Concepts — The Security Pattern Behind AgentWrit
 
-> **Document Version:** 2.0 | **Last Updated:** February 2026 | **Status:** Current
->
-> **Audience:** Developers, Operators, and Security Reviewers
->
-> **Prerequisites:** None — this is the starting point for understanding AgentWrit.
->
-> **Purpose:** Understand the problem AgentWrit solves, the security pattern behind it, and how all 8 components work together.
->
-> **Next steps:** [Getting Started](getting-started-user.md) | [Architecture](architecture.md) | [API Reference](api.md)
+AgentWrit implements the Ephemeral Agent Credentialing pattern — a security architecture purpose-built for AI agents. This page covers the full pattern: the industry context, the six principles, and all eight components that work together to eliminate the credential exposure problem.
 
 ---
 
@@ -157,7 +149,7 @@ sequenceDiagram
 
 **Solution:** AgentWrit issues JWT tokens with narrow scope limited to specific resources and actions. The scope format is `action:resource:identifier` (for example, `read:customers:12345`). Token TTL defaults to 5 minutes -- long enough for a task, short enough to limit exposure.
 
-Scope attenuation is a one-way operation: permissions can only be narrowed, never expanded. When an agent registers, its requested scope must be a subset of what the launch token allows. This ensures least-privilege access at every step.
+Scope attenuation is a one-way operation: permissions can never expand. A delegate can receive the same scope as its creator or less, but never more. When an agent registers, its requested scope must be covered by what the launch token allows. This ensures least-privilege access at every step.
 
 ```mermaid
 stateDiagram-v2
@@ -360,7 +352,7 @@ sequenceDiagram
 
 **Problem:** How do you prevent privilege escalation in multi-agent workflows? When Agent A delegates work to Agent B, which delegates to Agent C, how do you ensure that Agent C only has the permissions it legitimately needs? Without verification, a malicious agent could forge delegation claims to access resources it was never authorized to touch.
 
-**Solution:** A cryptographically signed delegation chain where permissions can only be narrowed (never expanded) at each hop. Each delegation step creates a signed record that is appended to the chain. A chain hash (SHA-256 of the serialized chain) is embedded in the token, making the chain tamper-evident. Maximum delegation depth is limited to 5 hops.
+**Solution:** A cryptographically signed delegation chain where permissions can never expand at each hop (same scope or narrower, never wider). Each delegation step creates a signed record that is appended to the chain. A chain hash (SHA-256 of the serialized chain) is embedded in the token, making the chain tamper-evident. Maximum delegation depth is limited to 5 hops.
 
 ```mermaid
 sequenceDiagram
@@ -611,7 +603,24 @@ The core lesson: agents should never hold long-lived secrets in their environmen
 
 ---
 
-## Next Steps
+---
 
-- **Developers:** Read [Getting Started: Developer](getting-started-developer.md) to integrate an agent with AgentWrit in 15 lines of Python
-- **Operators:** Read [Getting Started: Operator](getting-started-operator.md) to deploy the broker, configure apps, and create launch tokens
+## What's Next?
+
+You now understand the security pattern behind AgentWrit. Pick your next step:
+
+**[Architecture →](architecture.md)**
+See how the pattern maps to actual code — packages, components, and data flow diagrams.
+
+Or explore by interest:
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| Try the registration flow hands-on | [Your First Five Minutes](getting-started-user.md) |
+| See every API endpoint | [API Reference](api.md) |
+| Understand the scope system in detail | [Scopes and Permissions](scope-model.md) |
+| Find where a feature lives in the codebase | [Implementation Map](implementation-map.md) |
+
+---
+
+*Previous: [Documentation Home](README.md) · Next: [Architecture](architecture.md)*

--- a/docs/credential-model.md
+++ b/docs/credential-model.md
@@ -2,9 +2,9 @@
 
 ## The Core Guarantee
 
-**Permissions can only narrow as they flow through the system. No credential can ever grant more than the credential that created it.**
+**Permissions can never expand as they flow through the system. Each credential can grant the same scope as its creator or less — but never more.**
 
-This is the invariant that every design decision in AgentWrit traces back to. An operator sets up an app with a permission ceiling. The app creates launch tokens within that ceiling. Agents register with launch tokens and get scoped credentials. Agents delegate to other agents with even narrower scope. At every step, the scope can only shrink — never expand.
+This is the invariant that every design decision in AgentWrit traces back to. An operator sets up an app with a permission ceiling. The app creates launch tokens within that ceiling. Agents register with launch tokens and get scoped credentials. Agents can delegate to other agents with the same scope or narrower. At every step, `ScopeIsSubset` enforces the ceiling — a delegate can receive its delegator's full scope, but never exceed it.
 
 If an agent is compromised, the blast radius is provably contained to whatever scope it was granted. And the operator can kill it instantly at four levels of granularity.
 
@@ -367,7 +367,7 @@ graph TD
 The complete chain is hashed (SHA-256) into the `chain_hash` claim. If anyone tampers with the chain, the hash won't match.
 
 **Constraints:**
-- Scope can only narrow — `authz.ScopeIsSubset(delegated, delegator)` enforced
+- Scope can never expand — `authz.ScopeIsSubset(delegated, delegator)` enforced (same or narrower, never wider)
 - Maximum chain depth: **5 levels** — prevents unbounded delegation
 - Delegate must be a registered agent in the store — no delegation to unknown identities
 
@@ -406,19 +406,46 @@ Revocation is checked on every authenticated request (`ValMw.Wrap` → `revSvc.I
 
 ## The Complete Trust Chain
 
-```
-Admin Secret (permanent, root of trust)
-  └─→ Admin JWT (5 min, admin:* scopes)
-       ├─→ App Registration (one-time, sets scope ceiling)
-       │    └─→ App JWT (30 min, app:* scopes, ceiling-constrained)
-       │         └─→ Launch Token (30s, single-use, scope ≤ ceiling)
-       │              └─→ Agent JWT (task TTL, scope ≤ launch token)
-       │                   └─→ Delegated JWT (scope ≤ delegator, max depth 5)
-       └─→ Launch Token (dev/testing, NO ceiling — TD-013)
-            └─→ Agent JWT (no app traceability)
+```mermaid
+flowchart TB
+    SECRET["🔑 Admin Secret<br/><i>Permanent, root of trust</i>"]
+    
+    ADMIN["🛡️ Admin JWT<br/><i>5 min · admin:* scopes</i>"]
+    
+    subgraph Production Path
+        APP_REG["App Registration<br/><i>One-time · sets scope ceiling</i>"]
+        APP_JWT["📦 App JWT<br/><i>30 min · ceiling-constrained</i>"]
+        LAUNCH_P["🎫 Launch Token<br/><i>30s · scope ≤ ceiling</i>"]
+        AGENT_P["🤖 Agent JWT<br/><i>Task TTL · scope ≤ launch token</i>"]
+        DELEG["🔗 Delegated JWT<br/><i>scope ≤ delegator · max depth 5</i>"]
+    end
+
+    subgraph Bootstrap Path
+        LAUNCH_B["🎫 Launch Token<br/><i>Dev/testing · NO ceiling — TD-013</i>"]
+        AGENT_B["🤖 Agent JWT<br/><i>No app traceability</i>"]
+    end
+
+    SECRET --> ADMIN
+    ADMIN --> APP_REG
+    APP_REG --> APP_JWT
+    APP_JWT --> LAUNCH_P
+    LAUNCH_P --> AGENT_P
+    AGENT_P --> DELEG
+    ADMIN --> LAUNCH_B
+    LAUNCH_B --> AGENT_B
+
+    classDef root fill:#1a1a2e,stroke:#e94560,color:#fff,stroke-width:2px
+    classDef admin fill:#16213e,stroke:#0f3460,color:#fff
+    classDef prod fill:#0f3460,stroke:#53a8b6,color:#fff
+    classDef boot fill:#533483,stroke:#e94560,color:#fff
+
+    class SECRET root
+    class ADMIN admin
+    class APP_REG,APP_JWT,LAUNCH_P,AGENT_P,DELEG prod
+    class LAUNCH_B,AGENT_B boot
 ```
 
-At every arrow, the scope can only narrow. Every credential is audited, every credential has a defined lifetime, and every credential can be killed by the operator. That's the design.
+At every arrow, the scope can never expand — same or narrower, never wider. Every credential is audited, every credential has a defined lifetime, and every credential can be killed by the operator. That's the design.
 
 ---
 
@@ -458,3 +485,24 @@ At every arrow, the scope can only narrow. Every credential is audited, every cr
 | Endpoint | Required scope | Purpose |
 |----------|---------------|---------|
 | `POST /v1/app/launch-tokens` | `app:launch-tokens:*` | Create launch tokens (ceiling-constrained) |
+
+---
+
+## What's Next?
+
+You've seen every credential in the system. Next, understand why we built it this way:
+
+**[Design Decisions →](design-decisions.md)**
+The reasoning behind every major architectural choice — JWTs, Ed25519, SPIFFE, hash-chained audit, and more.
+
+Or explore related topics:
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| Integrate these credentials into your agent code | [Getting Started: Developer](getting-started-developer.md) |
+| Deploy and manage the broker in production | [Getting Started: Operator](getting-started-operator.md) |
+| Look up endpoint details | [API Reference](api.md) |
+
+---
+
+*Previous: [Scopes and Permissions](scope-model.md) · Next: [Design Decisions](design-decisions.md)*

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1,6 +1,6 @@
-# AgentWrit Design Decisions — Why We Built It This Way
+# Design Decisions — Why We Built It This Way
 
-> This document traces the reasoning behind every major design choice in AgentWrit. Not what the system does — why it does it that way. Each section starts with the problem we faced, the options we considered, and why we chose what we chose.
+Every design choice in AgentWrit traces back to a problem we faced, options we considered, and a reason we chose what we chose. This document tells you the "why" behind the architecture.
 
 ---
 
@@ -317,3 +317,25 @@ Each decision builds on the previous:
 9. **OAuth doesn't fit machine-to-machine ephemeral agents** → own token system, OIDC bridge as enterprise add-on
 10. **Admin launch token creation bypasses ceiling** → restrict to dev mode (TD-013)
 11. **Different failure scenarios need different blast radii** → four revocation levels
+
+---
+
+## What's Next?
+
+You understand why AgentWrit is built the way it is. Time to put it to use:
+
+**[Your First Five Minutes →](getting-started-user.md)**
+Run a local setup, walk through the registration flow, and get your first agent token.
+
+Or dive deeper:
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| Build AgentWrit into your agent code | [Getting Started: Developer](getting-started-developer.md) |
+| Deploy and operate the broker | [Getting Started: Operator](getting-started-operator.md) |
+| See the internal architecture and package map | [Architecture](architecture.md) |
+| Look up where features live in the codebase | [Implementation Map](implementation-map.md) |
+
+---
+
+*Previous: [The Credential Lifecycle](credential-model.md) · Next: [Your First Five Minutes](getting-started-user.md)*

--- a/docs/foundations.md
+++ b/docs/foundations.md
@@ -185,6 +185,40 @@ Tokens are not magic. Understanding their limits is as important as understandin
 
 ---
 
+## Token Lifecycle
+
+Every token in AgentWrit follows the same lifecycle, regardless of type:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Issued: Broker signs JWT
+    Issued --> Active: nbf time reached
+    Active --> Active: Used for requests
+    Active --> Renewed: POST /v1/token/renew<br/>(old token revoked)
+    Renewed --> Active: New JWT issued
+    Active --> Released: POST /v1/token/release<br/>(self-revoke)
+    Active --> Revoked: POST /v1/revoke<br/>(admin kills it)
+    Active --> Expired: exp time reached
+    Released --> [*]
+    Revoked --> [*]
+    Expired --> [*]
+
+    note right of Active
+        Every authenticated request
+        checks: not expired, not revoked,
+        scopes cover the endpoint
+    end note
+
+    note right of Expired
+        Background pruner removes
+        expired JTIs every 60s
+    end note
+```
+
+The key insight: tokens don't just expire — they can be **renewed** (extending the session with a new JWT while revoking the old one), **released** (self-revoked by the agent when done), or **revoked** (killed by the admin at any time). All three paths are distinct.
+
+---
+
 ## The Three Types of Token in AgentWrit
 
 With the foundation of what tokens are and why they matter, here's what AgentWrit actually issues:
@@ -220,8 +254,21 @@ Nonces aren't really "tokens" in the authorization sense — they're part of the
 
 ---
 
-## Now: What Are Scopes and How Do They Work?
+## What's Next?
 
-With tokens defined, scopes are what give tokens their meaning. A token without scopes is a proof of identity — it says who you are but not what you're allowed to do.
+Tokens make sense now. Next, understand who holds them and why:
 
-See [Scope Model](scope-model.md) for the complete scope deep dive: the format, the coverage rules, the four enforcement points, and how scopes flow through the attenuation chain.
+**[The Three Actors →](roles.md)**
+Operator, Application, Agent — each holds a different token with different authority.
+
+Or explore related topics:
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| See the permission system that gives tokens their meaning | [Scopes and Permissions](scope-model.md) |
+| Understand the full credential lifecycle with sequence diagrams | [The Credential Lifecycle](credential-model.md) |
+| Jump straight to getting a token | [Your First Five Minutes](getting-started-user.md) |
+
+---
+
+*Previous: [What Is AgentWrit?](agentwrit-explained.md) · Next: [The Three Actors](roles.md)*

--- a/docs/getting-started-developer.md
+++ b/docs/getting-started-developer.md
@@ -1,12 +1,8 @@
 # Getting Started: Developer
 
-> **Document Version:** 3.0 | **Last Updated:** March 2026 | **Status:** Current
->
-> **Audience:** Developer building an AI agent in Python, TypeScript, or Go.
->
-> **Prerequisite:** Your operator has deployed the broker and given you its URL and your allowed scopes. If you are the operator, see [Getting Started: Operator](getting-started-operator.md).
->
-> **Next steps:** [Common Tasks](common-tasks.md) | [API Reference](api.md) | [Troubleshooting](troubleshooting.md)
+Build an AI agent that authenticates with AgentWrit. This guide walks you through requesting tokens, using them in your code, and validating them at your resource server — in Python, TypeScript, or Go.
+
+**Prerequisites:** A running AgentWrit broker ([Your First Five Minutes](getting-started-user.md)) and familiarity with HTTP APIs.
 
 ## How It Works: The Registration Flow
 
@@ -30,9 +26,7 @@ The registration flow gives you full control over your keys. You manage the cryp
   - Python 3.8+ with `requests` and `cryptography`
   - Go 1.24+ with the standard library
 
-There is no AgentWrit SDK yet. Today, Go integrations should call the broker's HTTP API directly and perform the Ed25519 registration flow themselves.
-
-You will manage your own Ed25519 keys and follow the registration flow.
+The [AgentWrit Python SDK](https://github.com/devonartis/agentauth-python) handles the full agent lifecycle. This guide covers the raw HTTP API for any language.
 
 ---
 
@@ -243,7 +237,7 @@ else:
 
 ## Enforcing Scopes in Your Resource Server
 
-> **This is interim guidance.** When the AgentWrit SDK ships, it replaces these manual checks with a single function call. But the principle never changes: **validate first, check scope second, act third.** Never skip the scope check -- a valid token does not mean the agent is authorized for this specific action.
+> The principle never changes: **validate first, check scope second, act third.** Never skip the scope check — a valid token does not mean the agent is authorized for this specific action.
 
 Every resource server endpoint that accepts agent tokens must do three things, in order:
 
@@ -708,9 +702,24 @@ See [Getting Started: Operator — TLS/mTLS Configuration](getting-started-opera
 
 ---
 
-## Next Steps
+---
 
-- [Common Tasks](common-tasks.md) -- validation, delegation, error handling
-- [Concepts](concepts.md) -- understand why this works the way it does
-- [Troubleshooting](troubleshooting.md) -- exact error messages and fixes
-- [API Reference](api.md) -- complete endpoint documentation
+## What's Next?
+
+Your agent can authenticate. Now learn the everyday operations:
+
+**[Common Tasks →](common-tasks.md)**
+Token renewal, delegation, revocation, and audit queries.
+
+Or explore related topics:
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| Deploy and operate the broker | [Getting Started: Operator](getting-started-operator.md) |
+| See integration patterns for resource servers | [Integration Patterns](integration-patterns.md) |
+| Understand scopes in depth | [Scopes and Permissions](scope-model.md) |
+| Look up a specific endpoint | [API Reference](api.md) |
+
+---
+
+*Previous: [Your First Five Minutes](getting-started-user.md) · Next: [Getting Started: Operator](getting-started-operator.md)*

--- a/docs/getting-started-operator.md
+++ b/docs/getting-started-operator.md
@@ -1,14 +1,8 @@
 # Getting Started: Operator
 
-> **Document Version:** 3.0 | **Last Updated:** March 2026 | **Status:** Current
->
-> **Audience:** Platform Operator responsible for deploying and managing AgentWrit infrastructure.
->
-> **Prerequisite:** Read [Concepts](concepts.md) to understand why AgentWrit exists and what the 8-component security pattern provides. If you are a developer integrating an agent, see [Getting Started: Developer](getting-started-developer.md).
->
-> **Next steps:** [Common Tasks: Operator](common-tasks.md#operator-tasks) | [Troubleshooting](troubleshooting.md#operator-errors) | [Architecture](architecture.md)
+Deploy AgentWrit in production. This guide covers broker startup, TLS configuration, app registration, scope ceilings, monitoring, and everything an operator needs to run the system securely.
 
-This guide walks you through deploying the AgentWrit broker, configuring it, creating launch tokens for developers, and monitoring the system.
+**Prerequisites:** Familiarity with Linux administration, Docker, and TLS certificates.
 
 ---
 
@@ -131,10 +125,10 @@ All broker configuration is via environment variables prefixed `AA_`. Configurat
 | `AA_MAX_TTL` | int | `86400` | No | Maximum token TTL ceiling in seconds (24 hours). Tokens requesting longer TTL are clamped to this value. Set to `0` to disable the ceiling entirely. |
 | `AA_BIND_ADDRESS` | string | `"127.0.0.1"` | No | Bind address for the HTTP listener. Use `"0.0.0.0"` for Docker or to accept external connections. |
 | `AA_SIGNING_KEY_PATH` | string | `"./signing.key"` | No | Path to Ed25519 private key for token signing. If the file does not exist, a fresh key is generated and saved to this path on startup. |
-| `AA_AUDIENCE` | string | `"agentwrit"` | No | Expected `aud` claim in JWTs. Set to empty string to skip audience validation. |
+| `AA_AUDIENCE` | string | *(empty)* | No | Expected `aud` claim in JWTs. Unset or empty skips audience validation. Set to a non-empty value to enforce it. |
 | `AA_APP_TOKEN_TTL` | int | `1800` | No | TTL for app JWTs in seconds (30 minutes). Controls how long app-authenticated tokens last. |
 | `AA_SEED_TOKENS` | bool | `false` | No | Print seed launch and admin tokens to stdout on startup. **Development only** -- never enable in production. |
-| `AA_DB_PATH` | string | `"./data.db"` | No | Path to the SQLite database file for audit event persistence. The broker creates the file and table on first startup. Set to `""` to disable persistence (memory-only mode). See [Audit Persistence](#audit-persistence-aa_db_path) below. |
+| `AA_DB_PATH` | string | `"./data.db"` | No | Path to the SQLite database file for audit event persistence. The broker creates the file and table on first startup. Leaving this unset uses the default `./data.db`. See [Audit Persistence](#audit-persistence-aa_db_path) below. |
 | `AA_TLS_MODE` | string | `"none"` | No | Transport security mode: `none` (plain HTTP), `tls` (one-way TLS), `mtls` (mutual TLS). See [TLS/mTLS Configuration](#tlsmtls-configuration) below. |
 | `AA_TLS_CERT` | string | *(none)* | If TLS | Path to the broker's TLS certificate PEM file. Required when `AA_TLS_MODE` is `tls` or `mtls`. |
 | `AA_TLS_KEY` | string | *(none)* | If TLS | Path to the broker's TLS private key PEM file. Required when `AA_TLS_MODE` is `tls` or `mtls`. |
@@ -451,11 +445,35 @@ Example:
 - `FAIL` level logs go to stderr; all others go to stdout.
 - Log levels control verbosity: `quiet` (errors only), `standard` (normal operations), `verbose` (same as standard currently), `trace` (detailed debugging).
 
+### Background Maintenance
+
+The broker automatically runs two cleanup tasks every 60 seconds:
+
+- **JTI pruning** — removes expired JWT ID entries from the database to prevent unbounded growth
+- **Agent expiration** — marks inactive agents as expired when they exceed inactivity thresholds
+
+These run silently in the background. You'll see log entries like `pruned expired JTIs | count=42` when records are cleaned up. No operator action is required — this is fully automatic.
+
 ---
 
-## Next Steps
+---
 
-- [Common Tasks: Operator](common-tasks.md#operator-tasks) -- revocation, audit queries, launch token management
-- [Architecture](architecture.md) -- how the broker works internally
-- [Troubleshooting](troubleshooting.md#operator-errors) -- operational issues and fixes
-- [API Reference](api.md) -- complete endpoint documentation
+## What's Next?
+
+The broker is running in production. Now learn the day-to-day operations:
+
+**[Common Tasks →](common-tasks.md)**
+App management, token revocation, audit queries, and other everyday operations.
+
+Or explore related topics:
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| Understand the internal architecture | [Architecture](architecture.md) |
+| Use the CLI for all operator tasks | [CLI Reference (awrit)](awrit-reference.md) |
+| Debug issues | [Troubleshooting](troubleshooting.md) |
+| See all configuration options | [API Reference](api.md) |
+
+---
+
+*Previous: [Getting Started: Developer](getting-started-developer.md) · Next: [Common Tasks](common-tasks.md)*

--- a/docs/getting-started-user.md
+++ b/docs/getting-started-user.md
@@ -1,18 +1,8 @@
-# Getting Started with AgentWrit
+# Your First Five Minutes
 
----
+Get a local AgentWrit broker running and issue your first agent token. By the end, you'll have walked through the full registration flow — admin authentication, launch token creation, challenge-response identity, and token issuance.
 
-## Document Metadata
-
-| Property | Value |
-|----------|-------|
-| **Target Audience** | Absolute beginners; first-time users of AgentWrit |
-| **Persona** | Platform user or system administrator getting their first agent token |
-| **Document Version** | 3.0 |
-| **Last Updated** | 2026-03-29 |
-| **Prerequisites** | Docker, curl, and basic CLI familiarity |
-| **Estimated Time** | 15-20 minutes |
-| **Next Steps** | [Getting Started: Developer](getting-started-developer.md), [Getting Started: Operator](getting-started-operator.md), [Concepts](concepts.md) |
+**Prerequisites:** Docker, curl, and basic terminal familiarity. About 15 minutes.
 
 ---
 
@@ -118,46 +108,30 @@ The broker will log to stdout. You should see a "broker started" message.
 
 ## Architecture Overview
 
-AgentWrit provides a single registration flow to get tokens. Here's how it works:
+AgentWrit provides a single registration flow to get tokens. Here's the big picture:
 
-This hand-sketched diagram mirrors the same flow as the Mermaid diagram below. The embedded PNG gives readers a faster visual orientation, while the Mermaid source stays easy to maintain as the broker evolves.
+![Registration flow overview](diagrams/getting-started-auth-flow-sketch.png)
 
-![Hand-sketched registration overview](diagrams/getting-started-auth-flow-sketch.png)
+The flow has two phases: the **operator bootstrap** (steps 1–2) where the admin authenticates and creates a launch token, and the **agent registration** (steps 3–6) where the agent proves its identity and gets a scoped JWT. You'll walk through each step below.
 
 ```mermaid
 flowchart LR
-    Need["Agent needs a token"]
-
-    subgraph Operator["Operator bootstrap"]
+    subgraph You["What You'll Do"]
         direction TB
-        O1["1. Authenticate as admin"]
-        O2["2. Create launch token"]
-        O1 --> O2
+        S1["1️⃣ Authenticate<br/>as admin"]
+        S2["2️⃣ Create<br/>launch token"]
+        S3["3️⃣ Get nonce<br/>challenge"]
+        S4["4️⃣ Sign nonce<br/>with Ed25519"]
+        S5["5️⃣ Register<br/>with broker"]
+        S6["6️⃣ Use JWT<br/>as Bearer token"]
+        S1 --> S2 --> S3 --> S4 --> S5 --> S6
     end
 
-    subgraph Developer["Developer registration"]
-        direction TB
-        D1["3. Get nonce challenge"]
-        D2["4. Sign nonce"]
-        D3["5. Register with broker"]
-        D4["6. Use JWT"]
-        D1 --> D2 --> D3 --> D4
-    end
-
-    Need --> O1
-    O2 -->|"hand launch token to agent"| D1
-    D4 --> Ready["✓ Token ready to use"]
-
-    classDef operator fill:#e3f2fd,stroke:#42a5f5,color:#0d47a1
-    classDef developer fill:#e8f5e9,stroke:#66bb6a,color:#1b5e20
-    classDef outcome fill:#fff3e0,stroke:#ffb74d,color:#e65100
-
-    class O1,O2 operator
-    class D1,D2,D3,D4 developer
-    class Need,Ready outcome
+    classDef step fill:#0f3460,stroke:#53a8b6,color:#fff
+    class S1,S2,S3,S4,S5,S6 step
 ```
 
-The registration flow gives you full control over your keys. You manually perform cryptographic operations and send multiple requests. This design provides explicit transparency into every step of the identity and authorization process.
+For the full technical sequence diagram, see [Architecture → Data Flow Diagrams](architecture.md#data-flow-diagrams).
 
 ---
 
@@ -172,9 +146,7 @@ First, obtain an admin token using the shared admin secret:
 ```bash
 curl -s -X POST http://localhost:8080/v1/admin/auth \
   -H "Content-Type: application/json" \
-  -d '{
-    "secret": "my-secret-key-change-in-production"
-  }'
+  -d "{\"secret\": \"$AA_ADMIN_SECRET\"}"
 ```
 
 Response:
@@ -190,7 +162,7 @@ Save the admin token:
 ```bash
 ADMIN_TOKEN=$(curl -s -X POST http://localhost:8080/v1/admin/auth \
   -H "Content-Type: application/json" \
-  -d '{"secret": "my-secret-key-change-in-production"}' \
+  -d "{\"secret\": \"$AA_ADMIN_SECRET\"}" \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
 
 echo "Admin token saved: $ADMIN_TOKEN"
@@ -381,12 +353,17 @@ If you're deploying AgentWrit in production:
 - **[Getting Started: Operator](getting-started-operator.md)** -- Deploy the broker, manage scopes, configure persistence
 - **[Architecture](architecture.md)** -- Understand the internals and security design
 
+### See It In a Real App
+Want to see AgentWrit in a full application instead of raw curl commands?
+- **[MedAssist AI Demo](https://github.com/devonartis/agentauth-python/tree/main/demo)** -- Healthcare multi-agent pipeline with LLM tool-calling, delegation, and per-patient scoping
+- **[Support Ticket Demo](https://github.com/devonartis/agentauth-python/tree/main/demo2)** -- Three agents processing support tickets with streaming execution and natural token expiry
+
 ### For Everyone
 To deepen your understanding:
 - **[Concepts](concepts.md)** -- The security model, SPIFFE IDs, scope matching, token lifecycle
 - **[Troubleshooting](troubleshooting.md)** -- Common errors and how to fix them
 - **[API Reference](api.md)** -- Complete endpoint documentation with all parameters
-- **[Examples](examples/)** -- Complete working code samples in multiple languages
+- **[Scenarios](scenarios.md)** -- End-to-end walkthroughs for common use cases
 
 ### Quick Reference
 
@@ -475,11 +452,28 @@ For more detailed error messages and solutions, see [Troubleshooting](troublesho
 
 ---
 
-## Learn More
+---
 
-This guide covers the essential mechanics. For production deployments and advanced patterns:
+## What's Next?
 
-- **[Concepts](concepts.md)** -- The full security model, SPIFFE trust domain, audit chain
-- **[Getting Started: Operator](getting-started-operator.md)** -- Production deployment, TLS configuration, certificate management
-- **[Architecture](architecture.md)** -- Internal design, crypto details, token refresh mechanics
-- **[API Reference](api.md)** -- All endpoints, parameters, error codes
+You've seen the full registration flow. Pick your path:
+
+**[Getting Started: Developer →](getting-started-developer.md)**
+Integrate AgentWrit into your agent code — Python, TypeScript, or Go.
+
+**[Getting Started: Operator →](getting-started-operator.md)**
+Deploy the broker in production — TLS, persistence, monitoring.
+
+Or go deeper on the concepts:
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| Understand what tokens are and how JWTs work | [Foundations](foundations.md) |
+| See who holds which token and why | [The Three Actors](roles.md) |
+| Learn the scope system | [Scopes and Permissions](scope-model.md) |
+| Renew, delegate, or revoke tokens | [Common Tasks](common-tasks.md) |
+| Look up a specific endpoint | [API Reference](api.md) |
+
+---
+
+*Previous: [What Is AgentWrit?](agentwrit-explained.md) · Next: [Getting Started: Developer](getting-started-developer.md)*

--- a/docs/implementation-map.md
+++ b/docs/implementation-map.md
@@ -1,8 +1,6 @@
 # Implementation Map — Ephemeral Agent Credentialing v1.3
 
-> **Purpose:** Trace every component of the [Ephemeral Agent Credentialing v1.3](https://github.com/devonartis/AI-Security-Blueprints/blob/main/patterns/ephemeral-agent-credentialing/versions/v1.3.md) pattern to the exact Go file, function, and HTTP endpoint that implements it.
->
-> **Audience:** Contributors, security reviewers, and anyone who needs to verify that AgentWrit delivers what the pattern specifies.
+Trace every component of the security pattern to the exact Go file, function, and HTTP endpoint that implements it.
 
 ---
 
@@ -167,7 +165,7 @@ action:resource:identifier
 
 Examples: `read:data:*`, `admin:revoke:*`, `app:launch-tokens:*`
 
-Wildcard `*` in identifier covers any specific value. Scopes can only narrow, never expand.
+Wildcard `*` in identifier covers any specific value. Scopes can never expand — same or narrower, never wider.
 
 ---
 
@@ -348,7 +346,7 @@ POST /v1/delegate
 
 ### Security Properties
 
-- Scope can only narrow (attenuation is one-way)
+- Scope can never expand (same or narrower, never wider)
 - Max delegation depth: 5 hops
 - Each chain entry is signed with the broker's Ed25519 key
 - Chain hash embedded in JWT prevents chain tampering
@@ -439,3 +437,17 @@ Component 8: Prometheus metrics updated (request_duration, tokens_issued)
 ```
 
 Every component participates in every authenticated request. The pattern is not 8 separate features — it's 8 layers that compose on every operation.
+
+---
+
+## What's Next?
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| Understand the security pattern | [Concepts Deep Dive](concepts.md) |
+| See the full API | [API Reference](api.md) |
+| Return to the documentation home | [Documentation Home](README.md) |
+
+---
+
+*Previous: [Architecture](architecture.md) · Next: [Documentation Home](README.md)*

--- a/docs/integration-patterns.md
+++ b/docs/integration-patterns.md
@@ -1,14 +1,6 @@
 # Integration Patterns Guide for AgentWrit
 
-> **Document Version:** 2.0 | **Last Updated:** February 2026 | **Status:** Current
->
-> **Audience:** Developers, architects, and platform engineers implementing AgentWrit in production systems
->
-> **Prerequisites:** [Concepts](concepts.md), [API Reference](api.md), Python familiarity, REST API experience
->
-> **Time to read:** 45 minutes (all 6 patterns) or 5-10 minutes per pattern
->
-> **Next steps:** [Getting Started: Developer](getting-started-developer.md) for setup | [Troubleshooting](troubleshooting.md) for debugging
+Six proven patterns for integrating ephemeral credentialing into AI agent systems.
 
 ---
 
@@ -967,7 +959,7 @@ class LongLivedCredentialAgent:
 
 ### Use Case
 
-A hierarchical AI system where an orchestrator delegates progressively narrower scope to specialists. The orchestrator has broad access but can only delegate narrower scopes to child agents. Each delegation level is cryptographically signed and recorded in the audit trail.
+A hierarchical AI system where an orchestrator delegates scope to specialists. The orchestrator has broad access and can delegate the same scope or narrower to child agents — but never more than it holds. Each delegation level is cryptographically signed and recorded in the audit trail.
 
 ### When to Use
 
@@ -2180,4 +2172,15 @@ When implementing AgentWrit patterns, verify:
 
 ---
 
-**Questions?** See [Troubleshooting](troubleshooting.md) or check recent examples in `/docs/examples/`.
+## What's Next?
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| Walk through end-to-end scenarios | [Scenarios](scenarios.md) |
+| Debug common issues | [Troubleshooting](troubleshooting.md) |
+| Look up endpoints | [API Reference](api.md) |
+| Use the operator CLI | [CLI Reference (awrit)](awrit-reference.md) |
+
+---
+
+*Previous: [Common Tasks](common-tasks.md) · Next: [Scenarios](scenarios.md)*

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -1,6 +1,6 @@
-# Token Roles — Who Holds What and Why
+# The Three Actors — Who Holds What and Why
 
-> This document answers the question the codebase raises but doesn't say out loud: **which actor holds which token, what can they actually do with it, and why does the admin token have the ability to create agents?** Read this before `docs/credential-model.md`.
+Every token in the system is held by one of three actors. Each has a different job, a different token, and different authority. Understanding who holds what is the key to understanding how AgentWrit's security model works.
 
 ---
 
@@ -151,32 +151,75 @@ if !authz.ScopeIsSubset(req.AllowedScope, appRec.ScopeCeiling) {
 
 ---
 
+## The Three Actors — How They Interact
+
+```mermaid
+flowchart LR
+    subgraph Operator["🛡️ Operator"]
+        direction TB
+        OP_DESC["Human or deploy script<br/>Manages the system<br/>Holds: Admin JWT"]
+    end
+
+    subgraph Application["📦 Application"]
+        direction TB
+        APP_DESC["Software running in production<br/>Manages its own agents<br/>Holds: App JWT"]
+    end
+
+    subgraph Agent["🤖 Agent"]
+        direction TB
+        AG_DESC["AI agent executing a task<br/>Does the actual work<br/>Holds: Agent JWT"]
+    end
+
+    Operator -->|"registers app<br/>sets scope ceiling"| Application
+    Application -->|"creates launch token<br/>ceiling enforced"| Agent
+    Agent -.->|"can delegate to<br/>sub-agents"| Agent
+    Operator -->|"can revoke<br/>any credential"| Application
+    Operator -->|"can revoke<br/>any credential"| Agent
+
+    classDef op fill:#16213e,stroke:#0f3460,color:#fff
+    classDef app fill:#0f3460,stroke:#53a8b6,color:#fff
+    classDef ag fill:#2b4865,stroke:#256d85,color:#fff
+
+    class Operator op
+    class Application app
+    class Agent ag
+```
+
+---
+
 ## The Authority Chain in One Picture
 
-```
-Admin Secret  (root of trust — never travels, never expires)
-     │
-     ▼
-Admin JWT  (5 min, human/script — manages the system)
-     │
-     ├──► registers App → sets scope ceiling ["read:data:*", ...]
-     │
-     ▼
-App JWT  (30 min, software — manages its own agents)
-     │
-     │   ceiling check enforced here on every call
-     ▼
-Launch Token  (30s, one-time-use — delivered to the agent)
-     │
-     ▼
-Agent JWT  (task TTL, specific agent — does the work)
-     │
-     │   scope can only narrow on delegation
-     ▼
-Delegated JWT  (sub-agent — subset of parent's scope, max 5 levels)
+```mermaid
+flowchart TB
+    SECRET["🔑 Admin Secret<br/><i>Root of trust — never travels, never expires</i>"]
+    ADMIN["🛡️ Admin JWT<br/><i>5 min · human/script — manages the system</i>"]
+    APP["📦 App JWT<br/><i>30 min · software — manages its own agents</i>"]
+    LAUNCH["🎫 Launch Token<br/><i>30s · one-time-use — delivered to the agent</i>"]
+    AGENT["🤖 Agent JWT<br/><i>Task TTL · specific agent — does the work</i>"]
+    DELEG["🔗 Delegated JWT<br/><i>Sub-agent — subset of parent scope, max 5 levels</i>"]
+
+    SECRET -->|"authenticates"| ADMIN
+    ADMIN -->|"registers App<br/>sets scope ceiling"| APP
+    APP -->|"creates launch token<br/>ceiling enforced ✓"| LAUNCH
+    LAUNCH -->|"agent registers<br/>proves key ownership"| AGENT
+    AGENT -->|"delegates<br/>scope can never expand"| DELEG
+
+    classDef root fill:#1a1a2e,stroke:#e94560,color:#fff,stroke-width:2px
+    classDef admin fill:#16213e,stroke:#0f3460,color:#fff
+    classDef app fill:#0f3460,stroke:#53a8b6,color:#fff
+    classDef launch fill:#533483,stroke:#e94560,color:#fff
+    classDef agent fill:#2b4865,stroke:#256d85,color:#fff
+    classDef deleg fill:#334756,stroke:#548ca8,color:#fff
+
+    class SECRET root
+    class ADMIN admin
+    class APP app
+    class LAUNCH launch
+    class AGENT agent
+    class DELEG deleg
 ```
 
-At every step, authority can only narrow. The admin defines what apps can do. Apps define what agents can do. Agents define what sub-agents can do. No step can exceed the step above it — except the admin, who is the step above everything.
+At every step, authority can never expand. The admin defines what apps can do. Apps define what agents can do. Agents define what sub-agents can do. A delegate can receive its delegator's full scope or less — but never more. The admin, as root of trust, is the ceiling above everything.
 
 ---
 
@@ -202,9 +245,24 @@ At every step, authority can only narrow. The admin defines what apps can do. Ap
 
 ---
 
-## What to Read Next
+---
 
-- **`docs/credential-model.md`** — the full technical walkthrough: every credential's claims, TTLs, and sequence diagrams
-- **`docs/agentwrit-explained.md`** — the plain-language version for sales and new team members
+## What's Next?
 
+You know who holds which token. Next, understand what those tokens can actually *do*:
+
+**[Scopes and Permissions →](scope-model.md)**
+The `action:resource:identifier` format, coverage rules, and the four enforcement points.
+
+Or explore related topics:
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| See every credential's claims and TTLs | [The Credential Lifecycle](credential-model.md) |
+| Understand the full registration flow hands-on | [Your First Five Minutes](getting-started-user.md) |
+| See the plain-language version for sales teams | [What Is AgentWrit?](agentwrit-explained.md) |
+
+---
+
+*Previous: [Foundations](foundations.md) · Next: [Scopes and Permissions](scope-model.md)*
 

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -1,10 +1,10 @@
 # Real-World Scenarios — The 8 Components in Production
 
-> **Purpose:** Show how the 8 Ephemeral Agent Credentialing components work together in real production deployments. Each scenario is a real use case with real API calls.
->
-> **Audience:** Developers building agent systems, architects evaluating AgentWrit, security reviewers verifying coverage.
->
-> **Prerequisites:** [Concepts](concepts.md) for component definitions, [Implementation Map](implementation-map.md) for code tracing.
+These scenarios show how the Ephemeral Agent Credentialing components work together in production deployments with real API calls.
+
+**Want to run a real demo?** The [Python SDK](https://github.com/devonartis/agentauth-python) includes two working demo applications that implement these patterns against a live broker:
+- [MedAssist AI](https://github.com/devonartis/agentauth-python/tree/main/demo) — healthcare multi-agent pipeline with scope isolation, delegation, and LLM tool-calling
+- [Support Ticket Zero-Trust](https://github.com/devonartis/agentauth-python/tree/main/demo2) — three LLM-driven agents with streaming execution and natural token expiry
 
 ---
 
@@ -492,21 +492,28 @@ A bank operates AI agents across multiple branches. A central compliance agent o
 
 ### The Delegation Hierarchy
 
-```
-Central Compliance Agent (HQ)
-  scope: read:compliance:*, write:reports:*
-  │
-  ├── Regional Agent (Northeast)
-  │   scope: read:compliance:northeast, write:reports:northeast
-  │   │
-  │   ├── Branch Agent (Boston)
-  │   │   scope: read:compliance:northeast:boston
-  │   │
-  │   └── Branch Agent (NYC)
-  │       scope: read:compliance:northeast:nyc
-  │
-  └── Regional Agent (Southeast)
-      scope: read:compliance:southeast, write:reports:southeast
+```mermaid
+flowchart TB
+    HQ["🏛️ Central Compliance Agent (HQ)<br/><i>scope: read:compliance:*, write:reports:*</i>"]
+
+    NE["📍 Regional Agent (Northeast)<br/><i>scope: read:compliance:northeast, write:reports:northeast</i>"]
+    SE["📍 Regional Agent (Southeast)<br/><i>scope: read:compliance:southeast, write:reports:southeast</i>"]
+
+    BOS["🏢 Branch Agent (Boston)<br/><i>scope: read:compliance:northeast:boston</i>"]
+    NYC["🏢 Branch Agent (NYC)<br/><i>scope: read:compliance:northeast:nyc</i>"]
+
+    HQ -->|"delegates"| NE
+    HQ -->|"delegates"| SE
+    NE -->|"delegates"| BOS
+    NE -->|"delegates"| NYC
+
+    classDef hq fill:#1a1a2e,stroke:#e94560,color:#fff,stroke-width:2px
+    classDef regional fill:#16213e,stroke:#0f3460,color:#fff
+    classDef branch fill:#0f3460,stroke:#53a8b6,color:#fff
+
+    class HQ hq
+    class NE,SE regional
+    class BOS,NYC branch
 ```
 
 ### How Delegation Chains Work
@@ -771,3 +778,17 @@ func jsonBody(v interface{}) io.Reader {
 | `POST /v1/token/release` | 4+5. Release + Audit | `net/http` |
 
 **No JWT library needed.** The broker handles JWT creation and verification. The agent just sends HTTP requests and uses the token as an opaque bearer string.
+
+---
+
+## What's Next?
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| Debug common issues | [Troubleshooting](troubleshooting.md) |
+| Look up endpoints | [API Reference](api.md) |
+| See the internal architecture | [Architecture](architecture.md) |
+
+---
+
+*Previous: [Integration Patterns](integration-patterns.md) · Next: [Troubleshooting](troubleshooting.md)*

--- a/docs/scope-model.md
+++ b/docs/scope-model.md
@@ -10,13 +10,19 @@ Every credential in AgentWrit carries a list of scopes. Every protected endpoint
 
 Every scope has exactly three parts, separated by colons:
 
+| Part | Example | Meaning |
+|------|---------|---------|
+| **action** | `read` | What you're doing |
+| **resource** | `data` | What you're acting on |
+| **identifier** | `customers` | Which specific instance (or `*` for all) |
+
+Examples:
+
 ```
-action   : resource   : identifier
-───────    ─────────    ──────────
-read     : data       : customers
-write    : logs       : *
-admin    : revoke     : *
-app      : launch-tokens : *
+read:data:customers
+write:logs:*
+admin:revoke:*
+app:launch-tokens:*
 ```
 
 - **action** — what you're doing: `read`, `write`, `admin`, `app`
@@ -137,7 +143,7 @@ Task scopes are not predefined by the broker. They're defined by the operator wh
 
 ## Where Scopes Are Checked (The Four Enforcement Points)
 
-This is where the design gets concrete. Scopes are checked at four distinct points, and each point enforces the attenuation invariant: permissions can only narrow.
+This is where the design gets concrete. Scopes are checked at four distinct points, and each point enforces the attenuation invariant: permissions can never expand (same or narrower, never wider).
 
 ### Enforcement Point 1: App Creates Launch Token
 
@@ -284,7 +290,7 @@ graph TD
     style DJWT fill:#9370db,color:#fff
 ```
 
-At every arrow, `ScopeIsSubset` enforces that the new scope is covered by the previous scope. The chain can only narrow.
+At every arrow, `ScopeIsSubset` enforces that the new scope is covered by the previous scope. The chain can never expand — a delegate can receive its delegator's full scope, but never exceed it.
 
 ---
 
@@ -363,6 +369,27 @@ The answer depends on what matters more: developer convenience during bootstrapp
 - `*` in the identifier position is a wildcard covering all instances
 - `ScopeIsSubset` is the single function that enforces all permission checks
 - Scopes are checked at four enforcement points: app→launch token, launch token→agent, agent→delegate, and every endpoint access
-- At every step, scope can only narrow — the attenuation invariant
+- At every step, scope can never expand (same or narrower) — the attenuation invariant
 - Admin scopes (`admin:*:*`), app scopes (`app:*:*`), and task scopes are three distinct families
 - The admin launch token path bypasses EP1 (no ceiling check) — this is a known design question (TD-013), not a bug
+
+---
+
+## What's Next?
+
+Scopes control what tokens can do. Next, see every credential type in detail:
+
+**[The Credential Lifecycle →](credential-model.md)**
+Every credential's claims, TTLs, and how they flow through the attenuation chain.
+
+Or explore related topics:
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| See who holds which token | [The Three Actors](roles.md) |
+| Try the registration flow hands-on | [Your First Five Minutes](getting-started-user.md) |
+| Look up a specific API endpoint | [API Reference](api.md) |
+
+---
+
+*Previous: [The Three Actors](roles.md) · Next: [The Credential Lifecycle](credential-model.md)*

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,14 +1,6 @@
 # Troubleshooting
 
-> **Document Version:** 2.0 | **Last Updated:** February 2026 | **Status:** Current
->
-> **Audience:** Developers and Operators encountering errors in AgentWrit.
->
-> **Prerequisites:** [Getting Started: Developer](getting-started-developer.md) or [Getting Started: Operator](getting-started-operator.md).
->
-> **Next steps:** [API Reference](api.md) for endpoint details | [Common Tasks](common-tasks.md) for working examples.
->
-> This guide covers exact error messages, their causes, and fixes. Errors are organized by role: [Developer Errors](#developer-errors) and [Operator Errors](#operator-errors).
+Exact error messages, their causes, and fixes organized by role.
 
 ## Diagnostic Flowchart
 
@@ -196,7 +188,7 @@ Each nonce is also single-use. A nonce consumed by one registration attempt cann
 
 ### 403 at /v1/register: "requested scope exceeds allowed scope"
 
-**Cause:** Your `requested_scope` includes permissions not covered by the launch token's `allowed_scope`. Scopes can only narrow (attenuate), never expand.
+**Cause:** Your `requested_scope` includes permissions not covered by the launch token's `allowed_scope`. Scopes can never expand — every requested scope must be covered by the launch token's ceiling.
 
 **Fix:** Request a scope that is a subset of the allowed scope:
 
@@ -737,3 +729,59 @@ broker:
   volumes:
     - /etc/broker/certs:/certs:ro
 ```
+
+---
+
+## Prometheus Metrics Reference
+
+The broker exposes metrics at `GET /v1/metrics` in Prometheus format. Use these to monitor health, detect anomalies, and build dashboards.
+
+### Counters
+
+| Metric | Labels | What it measures |
+|--------|--------|-----------------|
+| `agentauth_tokens_issued_total` | `scope` | Total tokens issued, by scope |
+| `agentauth_tokens_revoked_total` | `level` | Revocations by level: `token`, `agent`, `task`, `chain` |
+| `agentauth_registrations_total` | `status` | Agent registrations: `success` or `failure` |
+| `agentauth_admin_auth_total` | `status` | Admin auth attempts: `success` or `failure` |
+| `agentauth_launch_tokens_created_total` | — | Launch tokens created via admin API |
+| `agentauth_clock_skew_total` | — | Clock skew events detected (token `nbf` in the future) |
+| `agentauth_audit_events_total` | `event_type` | Audit events recorded, by type |
+| `agentauth_db_errors_total` | `operation` | Database operation errors |
+
+### Gauges
+
+| Metric | What it measures |
+|--------|-----------------|
+| `agentauth_active_agents` | Current number of registered agents |
+| `agentauth_audit_events_loaded` | Audit events loaded from SQLite at startup (set once) |
+
+### Histograms
+
+| Metric | Labels | What it measures |
+|--------|--------|-----------------|
+| `agentauth_request_duration_seconds` | `endpoint` | Request duration by endpoint (e.g., `token_issue`) |
+| `agentauth_audit_write_duration_seconds` | — | Time to persist an audit event to SQLite |
+
+### Key Alerts to Consider
+
+- **`agentauth_admin_auth_total{status="failure"}` rising** — possible brute-force attempt on the admin secret
+- **`agentauth_registrations_total{status="failure"}` rising** — agents failing to register (expired launch tokens? wrong signatures?)
+- **`agentauth_tokens_revoked_total` spike** — mass revocation event, investigate the cause
+- **`agentauth_db_errors_total` > 0** — database issues, check SQLite file permissions and disk space
+- **`agentauth_clock_skew_total` > 0** — clock drift between broker and clients, check NTP
+
+---
+
+## What's Next?
+
+| If you want to... | Read this |
+|-------------------|-----------|
+| Look up endpoint details | [API Reference](api.md) |
+| Use the operator CLI | [CLI Reference (awrit)](awrit-reference.md) |
+| See the internal architecture | [Architecture](architecture.md) |
+| Find where features live in code | [Implementation Map](implementation-map.md) |
+
+---
+
+*Previous: [Scenarios](scenarios.md) · Next: [API Reference](api.md)*


### PR DESCRIPTION
## Summary

- Fixes 9 doc accuracy issues found in P1/P2 audit
- Docs-layout-archon-style content sweep across all `docs/` files
- One infra fix: `docker-compose.yml` network name (`agentauth-net` → `agentwrit-net`)

## Audit fixes

| Severity | File | What |
|---|---|---|
| P1 | `docs/getting-started-user.md` | Admin auth examples used hardcoded `"my-secret-key-change-in-production"` — would cause 401 on first run. Fixed to use `$AA_ADMIN_SECRET`. |
| P1 | `docs/awrit-reference.md` | `awrit init` sample output showed `~/.agentwrit/config` → corrected to `~/.broker/config` |
| P1 | `docs/api.md` | JWT claims table: `iss` is `AA_ISSUER` (empty by default, not always `"agentwrit"`); app subject is `app:{internal_app_id}` not `app:{client_id}`; `aud` driven by `AA_AUDIENCE`, omitted if unset |
| P2 | `docs/getting-started-operator.md` | `AA_AUDIENCE` default was `"agentwrit"` → corrected to empty. SQLite memory-mode fallback claim removed (false — empty `AA_DB_PATH` falls back to `./data.db`) |
| P2 | `docs/api/openapi.yaml` | License `Apache-2.0` → `AGPL-3.0` with correct URL |
| Low | `docker-compose.yml` | Network `agentauth-net` → `agentwrit-net` (brand sweep miss from `684083b`) |
| Low | `docs/README.md` | Endpoint count 22 → 19 (verified from route registration); component count seven → eight |
| Low | `docs/concepts.md` | Component count seven → eight |

## Tech debt logged

- **TD-CLI-002** (HIGH) — `awrit init` writes to `~/.agentauth/config`, broker reads `~/.broker/config`. Introduced in `4e197a5`. Bug report at `.plans/bugs/BUG-CLI-002-awrit-init-config-path.md`. Needs a separate `fix/` branch.
- **TD-CLI-003** (Low) — docker-compose network name lag (resolved in this PR).

## Intentionally not changed

- `urn:agentauth:error:` in `problemdetails.go` and `agentauth_*` metric names in `obs.go` — docs already reflect the planned renamed state; code-side rebrand is separate work.

## Test plan

- [ ] CI gates pass (docker-compose.yml touched → full pipeline runs)
- [ ] `go test ./...` green (no Go source changes)
- [ ] Docker build succeeds with renamed network