### PR TITLE
ci: add main-hygiene gate + TD-CI-002/003 tech debt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ name: CI
 # - docker-build
 # - smoke-l25
 # - sbom
+# - main-hygiene
 # GATE_LIST_END
 
 on:
@@ -278,6 +279,69 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - run: ./scripts/test-gate-parity.sh
 
+  # main-hygiene only runs on push to main (the branch where strip-target
+  # paths must not exist). On PR runs it auto-skips via the `if:` guard
+  # because PRs target develop, which legitimately carries these files.
+  # On main this is the automated safety net that catches a missed
+  # ./scripts/strip_for_main.sh — a strip-target file slipping through
+  # would otherwise only be caught by manual review after-the-fact.
+  # Keep the STRIP_PATHS array in sync with scripts/strip_for_main.sh
+  # and the mirror block in scripts/gates.sh.
+  main-hygiene:
+    name: main-hygiene
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Main must not contain dev-only paths
+        run: |
+          STRIP_PATHS=(
+            "MEMORY.md"
+            "MEMORY_ARCHIVE.md"
+            "FLOW.md"
+            "TECH-DEBT.md"
+            "AGENTS.md"
+            "CLAUDE.md"
+            "COWORK_SESSION.md"
+            "COWORK_DOCS_AUDIT.md"
+            ".active_module"
+            ".plans"
+            ".claude"
+            ".agents"
+            "audit"
+            "adr"
+            ".vscode"
+            "generate_pdf.py"
+          )
+          found=0
+          for path in "${STRIP_PATHS[@]}"; do
+            if [[ -e "$path" ]]; then
+              echo "FAIL: dev-only path found on main: $path"
+              found=$((found + 1))
+            fi
+          done
+          # Glob patterns (match strip_for_main.sh)
+          for f in AgentAuth_*.docx docs/QA_REPORT_*.md; do
+            if [[ -e "$f" ]]; then
+              echo "FAIL: dev-only glob match found on main: $f"
+              found=$((found + 1))
+            fi
+          done
+          for f in tests/*/evidence/DOC-AUDIT-REPORT.md; do
+            if [[ -e "$f" ]]; then
+              echo "FAIL: dev-only test audit report found on main: $f"
+              found=$((found + 1))
+            fi
+          done
+          if [[ $found -gt 0 ]]; then
+            echo ""
+            echo "$found strip-target path(s) found on main."
+            echo "These files are dev-only and must be stripped before landing."
+            echo "Fix: ./scripts/strip_for_main.sh (run mid-merge per its docs)."
+            exit 1
+          fi
+          echo "PASS: main is clean of dev-only paths"
+
   gates-passed:
     name: gates-passed
     runs-on: ubuntu-latest
@@ -296,6 +360,7 @@ jobs:
       - smoke-l25
       - sbom
       - gate-parity
+      - main-hygiene
     if: always()
     steps:
       - name: Check all gates passed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `main-hygiene` CI gate (2026-04-12)
+
+- **`.github/workflows/ci.yml`** — new `main-hygiene` job greps for strip-target paths on pushes to `main`. Runs only when `github.ref == 'refs/heads/main'` so PR runs against `develop` are untouched (develop legitimately carries these files). Fails the `gates-passed` aggregator if any dev-only file slips onto `main` via a missed `strip_for_main.sh` invocation — an automated safety net on top of the existing manual strip script.
+- **`scripts/gates.sh`** — mirror of the new gate in `GATES_FULL` so `scripts/test-gate-parity.sh` passes. Local invocation skips with `skip_gate` unless the current branch is `main`, since a developer running `gates.sh full` on `develop` would otherwise get a spurious failure.
+- **`TECH-DEBT.md`** — TD-CI-002 (Docker image publishing to Docker Hub) and TD-CI-003 (automated develop→main PR workflow) added with full specs. Both are follow-on work unlocked by the rebrand landing.
+
 ### Fixed — Runtime rebrand alignment (2026-04-12)
 
 - **`internal/problemdetails/problemdetails.go`** — RFC 7807 problem `type` URNs now use `urn:agentwrit:error:{errType}` instead of the former `urn:agentauth:error:{errType}` namespace, matching the published API docs.

--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -357,6 +357,38 @@ Audit triggered by discovery of hardcoded `iss: "agentauth"` in `internal/token/
 
 | TD-CLI-002 | ~~**`awrit init` writes config to `~/.agentauth/config` but broker reads `~/.broker/config`** — broken first-run path~~ | ~~HIGH~~ | **RESOLVED 2026-04-12** — `resolveConfigPath()` now defaults to `~/.broker/config` and fallback `/etc/broker/config`; unit test added. Branch `fix/rebrand-runtime-doc-alignment`. | `cmd/awrit/init_cmd.go:53-64`, `cmd/awrit/init_cmd_test.go` |
 | TD-CLI-003 | **`docker-compose.yml` network still named `agentauth-net`** — docs say `agentwrit-net` after brand sweep | Low | Next compose-touching PR | `docker-compose.yml:35,42` |
+| TD-CI-002 | **Docker image build + push to Docker Hub** — `docker-build` CI gate builds the image and discards it; there is no release workflow that tags and publishes to a registry so operators can `docker pull agentwrit:latest` | **HIGH** | Before public release | `.github/workflows/` (new workflow), `docs/getting-started-operator.md`, `README.md` |
+| TD-CI-003 | **Automated `develop → main` PR workflow** — today develop → main is a direct strip-push with admin bypass. Should be a GHA that checks out main, merges develop, runs strip, opens a PR back to main, and the PR goes through all CI gates (main-hygiene included). Removes the "forgot to run strip" risk entirely. | **HIGH** | After TD-CI-002 | `.github/workflows/` (new workflow), potentially tighten branch protection on main to remove admin bypass |
+
+### TD-CI-002 Detail: Docker image publishing to Docker Hub
+
+**Current state:** `.github/workflows/ci.yml` has a `docker-build` job that runs `docker build -t agentwrit-ci:${{ github.sha }} .` on every PR and develop/main push. The image is built, verified to compile, then thrown away. No registry push.
+
+**Target state:** On push to `main` and on release tags, build the multi-arch (amd64 + arm64) image and push to **Docker Hub** as `devonartis/agentwrit:<tag>`. Tagging scheme:
+- `latest` — always tracks `main`
+- `main-<sha>` — every main push, for reproducibility
+- `v<semver>` — release tags (e.g. `v2.0.0`, `v2.0`, `v2`)
+- `develop` — optional, tracks `develop` branch for early adopters
+
+**Why Docker Hub (not GHCR):** operator UX. `docker pull devonartis/agentwrit` is the familiar path for most operators. GHCR is fine but adds a step (login / allow-list). Revisit if we move off Docker Hub for rate limit or licensing reasons.
+
+**What the workflow needs:**
+1. New `.github/workflows/release.yml` (or extend ci.yml) triggered on `push: [main]` and `push: { tags: [v*] }`
+2. `docker/login-action` with `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets
+3. `docker/setup-qemu-action` + `docker/setup-buildx-action` for multi-arch
+4. `docker/build-push-action` with `platforms: linux/amd64,linux/arm64` and appropriate tags
+5. Optional: SBOM + cosign signing for supply-chain integrity (already have syft; add cosign)
+
+**Docs that need updating once published:**
+- `README.md` — add `docker pull devonartis/agentwrit:latest` to Quick Start
+- `docs/getting-started-operator.md` — add a "Docker image" section with pull + run examples
+- `docs/getting-started-user.md` — mention pre-built image as an alternative to `git clone`
+- `CHANGELOG.md` — Added entry per release
+- `docker-compose.yml` — document how to use `image: devonartis/agentwrit:latest` instead of `build: .`
+
+**Secrets required:** `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` (scoped to the agentwrit repo only, not user-wide). Set via GitHub repo secrets.
+
+**Exit criteria:** `docker pull devonartis/agentwrit:latest && docker run devonartis/agentwrit` starts a broker with the documented env vars, passes the L2.5 smoke test when pointed at it, and the image has a valid SBOM and (optionally) a cosign signature.
 
 ### TD-CLI-002 Detail: awrit init config path mismatch — RESOLVED 2026-04-12
 

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -38,6 +38,7 @@ GATES_FULL=(
   docker-build
   smoke-l25
   sbom
+  main-hygiene
 )
 
 if [[ "$MODE" == "--list-gates" ]]; then
@@ -174,6 +175,37 @@ if [[ "$MODE" == "full" ]]; then
     run_gate "sbom" syft scan dir:. -o spdx-json=sbom.spdx.json --quiet
   else
     skip_gate "sbom" "syft not installed — brew install syft or https://github.com/anchore/syft"
+  fi
+
+  # Main-hygiene: strip-target paths must not exist on main. Only runs
+  # when actually checked out to main, since develop legitimately carries
+  # these files. Mirrors the main-hygiene job in ci.yml — keep the
+  # STRIP_PATHS list below in sync with that job AND with
+  # scripts/strip_for_main.sh.
+  CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')"
+  if [[ "$CURRENT_BRANCH" == "main" ]]; then
+    STRIP_PATHS=(
+      "MEMORY.md" "MEMORY_ARCHIVE.md" "FLOW.md" "TECH-DEBT.md"
+      "AGENTS.md" "CLAUDE.md" "COWORK_SESSION.md" "COWORK_DOCS_AUDIT.md"
+      ".active_module" ".plans" ".claude" ".agents" "audit" "adr"
+      ".vscode" "generate_pdf.py"
+    )
+    run_gate "main-hygiene" bash -c '
+      STRIP_PATHS=('"${STRIP_PATHS[*]@Q}"')
+      found=0
+      for p in "${STRIP_PATHS[@]}"; do
+        if [[ -e "$p" ]]; then
+          echo "FAIL: dev-only path found on main: $p"
+          found=$((found + 1))
+        fi
+      done
+      for f in AgentAuth_*.docx docs/QA_REPORT_*.md tests/*/evidence/DOC-AUDIT-REPORT.md; do
+        [[ -e "$f" ]] && { echo "FAIL: dev-only glob match: $f"; found=$((found + 1)); }
+      done
+      [[ $found -eq 0 ]]
+    '
+  else
+    skip_gate "main-hygiene" "not on main branch (current: $CURRENT_BRANCH)"
   fi
 fi
 


### PR DESCRIPTION
## Summary

Adds an automated safety net for the develop → main strip-merge flow, plus logs the follow-on tech debt that emerged from this session.

## `main-hygiene` CI gate

New job in `.github/workflows/ci.yml` that greps for strip-target paths and fails the build if any dev-only file exists on `main`. Runs only on `push: [main]` — PR runs against `develop` auto-skip (develop legitimately carries these files).

**Why:** Today the strip flow is a local script + admin bypass. If I forget to run `scripts/strip_for_main.sh`, nothing catches it until someone notices a red X on GitHub hours later. The `.vscode/` incident during the M-sec cycle is the prior art — a file slipped onto main because the strip script and the pre-commit hook disagreed about what to strip.

**What the gate catches:** `MEMORY.md`, `FLOW.md`, `TECH-DEBT.md`, `MEMORY_ARCHIVE.md`, `CLAUDE.md`, `AGENTS.md`, `COWORK_*.md`, `.active_module`, `.plans/`, `.claude/`, `.agents/`, `audit/`, `adr/`, `.vscode/`, `generate_pdf.py`, `AgentAuth_*.docx`, `docs/QA_REPORT_*.md`, `tests/*/evidence/DOC-AUDIT-REPORT.md`.

**Kept in sync:** `scripts/strip_for_main.sh` (authoritative), `ci.yml` `main-hygiene` job, `scripts/gates.sh` mirror block. Drift is still possible — TD noted that a future cycle should refactor to a single shared list file.

## `scripts/gates.sh` mirror

Added `main-hygiene` to `GATES_FULL` so `scripts/test-gate-parity.sh` passes. Local invocation skips the check unless the current branch is `main` (a developer running `gates.sh full` on `develop` would otherwise trip on its own dev files).

## Tech debt logged

- **TD-CI-002 (HIGH)** — Docker image build + push to Docker Hub as `devonartis/agentwrit:latest`, `:main-<sha>`, `:v<semver>`. Multi-arch (amd64 + arm64), SBOM, optional cosign signing. Full spec incl. docs updates (README, getting-started-operator, getting-started-user). Secrets: `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`. Unblocks public operator UX (`docker pull devonartis/agentwrit`).
- **TD-CI-003 (HIGH)** — Automated `develop → main` PR workflow that merges develop, runs strip, opens a PR back to main. Removes the admin-bypass direct-push flow entirely. Combined with tightening branch protection on main, this closes the "forgot to run strip" risk at the source. `main-hygiene` is the interim alert; TD-CI-003 is the permanent fix.

## Test plan

- [ ] CI runs the full pipeline on this PR (runs against develop)
- [ ] `main-hygiene` job is SKIPPED on this PR (confirm in job list — `if:` guard evaluates false)
- [ ] `gate-parity` job passes (gates.sh `--list-gates` matches ci.yml `GATE_LIST` — 14 gates)
- [ ] Post-merge, when develop → main strip-merge lands, the `main-hygiene` job runs on the main push and passes (main has no strip targets)
- [ ] If I'm forgetful and push a strip-target file to main by accident, `main-hygiene` fails loudly within ~30s