### PR TITLE
ci(release): publish multi-arch image to Docker Hub + cosign signing (TD-CI-002)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,146 @@
+name: Release — publish image to Docker Hub
+
+# When this workflow fires:
+#   - push to main: publishes `devonartis/agentwrit:latest` and
+#     `devonartis/agentwrit:main-<sha>` so every main commit is traceable.
+#   - push of a `v*` tag: publishes semver tags `v2.0.0`, `v2.0`, `v2` AND
+#     updates `latest`. Tag the release commit AFTER it lands on main so the
+#     same image is promoted (not rebuilt) when possible.
+#
+# Why not on `develop` or PRs: `develop` is private dev state (we don't want
+# that image downloaded by operators), and PR runs can't access secrets on
+# public repos — so DOCKERHUB_TOKEN would be empty and the login step fails.
+#
+# What this workflow needs (set manually, one-time):
+#   - Docker Hub repo `devonartis/agentwrit` exists and is public
+#   - GitHub repo secrets:
+#       DOCKERHUB_USERNAME = devonartis
+#       DOCKERHUB_TOKEN    = PAT scoped to read+write on agentwrit only
+#
+# Multi-arch note: amd64 + arm64 built via QEMU emulation on the x86 runner.
+# Build is ~2-3x longer than amd64-only but covers Apple Silicon, Raspberry
+# Pi, and ARM cloud hosts. If this becomes a bottleneck, switch to a matrix
+# with native arm64 runners (GitHub's arm64 hosted runners are in preview
+# for public repos — TD worth opening when we're paying attention to build
+# latency).
+#
+# Supply-chain: the released image is signed with cosign keyless
+# (OIDC-issued Sigstore certificate from GitHub Actions workload identity).
+# Verify with:
+#   cosign verify devonartis/agentwrit:latest \
+#     --certificate-identity-regexp='^https://github.com/devonartis/agentwrit/.github/workflows/release.yml@' \
+#     --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false  # never cancel a release mid-push
+
+permissions:
+  contents: read
+  packages: write        # not used for Docker Hub, but future-proof if we mirror to GHCR
+  id-token: write        # required for cosign keyless signing (OIDC)
+
+jobs:
+  publish:
+    name: publish-dockerhub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up QEMU (for arm64 via emulation)
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract image metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
+        with:
+          images: devonartis/agentwrit
+          # Tagging strategy:
+          #   - `latest`          — only on default branch push (main)
+          #   - `main-<sha>`      — every main push for reproducibility
+          #   - `v1.2.3` etc.     — semver tags when a release tag is pushed
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=main-${{ github.sha }},enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
+
+      - name: Build and push multi-arch image
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          target: broker
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003  # v4.1.1
+
+      - name: Sign the published image (keyless)
+        # Signs EVERY tag the build-push step emitted, using the image digest
+        # to avoid signing a moving target. Keyless mode uses GitHub OIDC to
+        # get a short-lived Sigstore certificate — no long-lived signing key
+        # to rotate or leak. Verify on the pull side with `cosign verify`.
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          for tag in $TAGS; do
+            echo "Signing ${tag}@${DIGEST}"
+            cosign sign --yes "${tag}@${DIGEST}"
+          done
+
+      - name: Publish summary
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          {
+            echo "## Published image"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Registry | Docker Hub |"
+            echo "| Repository | \`devonartis/agentwrit\` |"
+            echo "| Digest | \`${DIGEST}\` |"
+            echo "| Platforms | \`linux/amd64\`, \`linux/arm64\` |"
+            echo "| Signed | keyless (cosign + Sigstore) |"
+            echo ""
+            echo "### Tags"
+            for tag in $TAGS; do
+              echo "- \`$tag\`"
+            done
+            echo ""
+            echo "### Pull"
+            echo '```bash'
+            echo "docker pull devonartis/agentwrit:latest"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,11 @@ sbom.spdx.json
 # strip_for_main.sh and .githooks/pre-commit both enforce this for main;
 # ignoring it in .gitignore prevents accidental commits on ANY branch.
 .vscode/
+
+# Credential scratch pads — any filename containing TOKEN / SECRET / CREDENTIAL
+# is assumed to be a temporary holding spot for a real secret and must never
+# be committed. If a legitimate config file needs one of these words in its
+# name, allow-list it explicitly with a negation pattern (e.g. !config/example_TOKEN.yaml).
+*TOKEN*
+*SECRET*
+*CREDENTIAL*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Docker Hub image publishing + cosign signing (TD-CI-002, 2026-04-12)
+
+- **`.github/workflows/release.yml`** — new workflow that publishes multi-arch (`linux/amd64` + `linux/arm64`) broker images to Docker Hub on every push to `main` and on `v*` release tags. Tags produced: `latest` (tracks main), `main-<sha>` (per-commit traceability), `v<major>.<minor>.<patch>` / `v<major>.<minor>` / `v<major>` (semver releases). Builds with buildx + QEMU emulation on the hosted x86 runner; cached via `type=gha` so repeat builds are fast.
+- **Cosign keyless signing** — every published image is signed with Sigstore via GitHub Actions OIDC. No long-lived signing key to rotate. Verification command published in the README and `docs/getting-started-operator.md`.
+- **SLSA provenance + SBOM attestation** — `docker/build-push-action` emits provenance (`mode=max`) and SBOM alongside the image.
+- **`Dockerfile`** — added OCI image labels (`org.opencontainers.image.title/description/vendor/licenses/source/url/documentation`) as bake-time defaults, plus `-trimpath` on the Go build for reproducibility. The release workflow overrides `revision`, `version`, and `created` labels at publish time via `docker/metadata-action`.
+- **`README.md`** — new "Option A: Pre-built image from Docker Hub" section in Quick Start, now the recommended onboarding path ahead of source builds. Includes signature verification command.
+- **`docs/getting-started-operator.md`** — restructured "Quick Start" into three deployment options (pre-built image / Docker Compose local build / native binary). Pre-built image is the new default with full pull/run/verify walkthrough and OCI-image inventory.
+- **`docker-compose.yml`** — added commented-out `image: devonartis/agentwrit:latest` as an alternative to `build: .` so operators can swap without editing the compose file structurally. Also fixed stale `AA_DB_PATH` default (`agentauth.db` → `data.db`) missed in the earlier brand sweep.
+- **`TECH-DEBT.md`** — TD-CI-002 marked RESOLVED with link to this branch.
+
+**Required manual setup before first release:**
+1. Docker Hub repo `devonartis/agentwrit` must exist (public)
+2. Docker Hub PAT with read/write scope to `agentwrit` only
+3. GitHub repo secrets: `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN`
+
 ### Added — `main-hygiene` CI gate (2026-04-12)
 
 - **`.github/workflows/ci.yml`** — new `main-hygiene` job greps for strip-target paths on pushes to `main`. Runs only when `github.ref == 'refs/heads/main'` so PR runs against `develop` are untouched (develop legitimately carries these files). Fails the `gates-passed` aggregator if any dev-only file slips onto `main` via a missed `strip_for_main.sh` invocation — an automated safety net on top of the existing manual strip script.
 - **`scripts/gates.sh`** — mirror of the new gate in `GATES_FULL` so `scripts/test-gate-parity.sh` passes. Local invocation skips with `skip_gate` unless the current branch is `main`, since a developer running `gates.sh full` on `develop` would otherwise get a spurious failure.
-- **`TECH-DEBT.md`** — TD-CI-002 (Docker image publishing to Docker Hub) and TD-CI-003 (automated develop→main PR workflow) added with full specs. Both are follow-on work unlocked by the rebrand landing.
+- **`TECH-DEBT.md`** — TD-CI-003 (automated develop→main PR workflow) added as follow-on work.
 
 ### Fixed — Runtime rebrand alignment (2026-04-12)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,26 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux go build -o broker ./cmd/broker
+# Embed VCS info into the binary for reproducibility traces (go build -buildvcs=true
+# is default in 1.24, but -trimpath keeps the build reproducible across hosts).
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o broker ./cmd/broker
 
 # Stage 2: Broker image
 FROM alpine:3.21 AS broker
+
+# OCI image labels — populated by docker/metadata-action in the release workflow.
+# Static labels (title/licenses/vendor) are baked in here so they're correct even
+# when someone does a plain `docker build .` locally without the metadata action.
+# Dynamic labels (revision/version/created/source) are overridden by the release
+# workflow's --label flags; the bake-time defaults below are only used for local
+# builds and non-release CI runs.
+LABEL org.opencontainers.image.title="AgentWrit" \
+      org.opencontainers.image.description="Ephemeral agent credentialing broker — short-lived, scope-attenuated tokens for AI agents" \
+      org.opencontainers.image.vendor="devonartis" \
+      org.opencontainers.image.licenses="AGPL-3.0-only" \
+      org.opencontainers.image.source="https://github.com/devonartis/agentwrit" \
+      org.opencontainers.image.url="https://github.com/devonartis/agentwrit" \
+      org.opencontainers.image.documentation="https://github.com/devonartis/agentwrit/blob/main/README.md"
 
 RUN apk --no-cache add ca-certificates sqlite curl
 WORKDIR /root/

--- a/README.md
+++ b/README.md
@@ -47,9 +47,42 @@ This release validates that AgentAuth is a working implementation of the target 
 
 ## Quick Start
 
-Prerequisites: [Go 1.24+](https://go.dev/dl/), [Docker](https://docs.docker.com/get-docker/), and [Docker Compose](https://docs.docker.com/compose/install/).
+Prerequisites: [Docker](https://docs.docker.com/get-docker/) (plus [Go 1.24+](https://go.dev/dl/) and [Docker Compose](https://docs.docker.com/compose/install/) for source builds).
 
-### Option A: Docker Compose (recommended)
+### Option A: Pre-built image from Docker Hub (fastest)
+
+The signed, multi-arch (`linux/amd64` + `linux/arm64`) broker image is published to Docker Hub on every push to `main` and on release tags. Pull and run directly — no clone required.
+
+```bash
+# 1. Set a strong admin secret (required — broker exits without it)
+export AA_ADMIN_SECRET="$(openssl rand -base64 32)"
+
+# 2. Pull and run
+docker run --rm -p 8080:8080 \
+  -e AA_ADMIN_SECRET \
+  -e AA_BIND_ADDRESS=0.0.0.0 \
+  -v agentwrit-data:/data \
+  -e AA_DB_PATH=/data/data.db \
+  -e AA_SIGNING_KEY_PATH=/data/signing.key \
+  devonartis/agentwrit:latest
+
+# 3. In another terminal, verify health
+curl -s http://localhost:8080/v1/health | jq .
+```
+
+Available tags: `latest` (always tracks `main`), `main-<sha>` (every commit), `v<major>.<minor>.<patch>` / `v<major>.<minor>` / `v<major>` (release tags).
+
+**Verifying the image signature** (optional, recommended for production):
+
+```bash
+cosign verify devonartis/agentwrit:latest \
+  --certificate-identity-regexp='^https://github.com/devonartis/agentwrit/\.github/workflows/release\.yml@' \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+```
+
+Signed keyless with Sigstore via GitHub Actions OIDC — no long-lived signing key to rotate.
+
+### Option B: Docker Compose (clone + build locally)
 
 ```bash
 # 1. Clone and enter the repo
@@ -73,7 +106,9 @@ curl -s -X POST http://localhost:8080/v1/admin/auth \
 # {"access_token":"eyJ...","expires_in":300,"token_type":"Bearer"}
 ```
 
-### Option B: Build from source
+To use the pre-built image with Compose instead of a local build, edit `docker-compose.yml` and replace the `build: .` block with `image: devonartis/agentwrit:latest`.
+
+### Option C: Build from source
 
 ```bash
 # 1. Build the broker and operator CLI

--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -357,38 +357,8 @@ Audit triggered by discovery of hardcoded `iss: "agentauth"` in `internal/token/
 
 | TD-CLI-002 | ~~**`awrit init` writes config to `~/.agentauth/config` but broker reads `~/.broker/config`** — broken first-run path~~ | ~~HIGH~~ | **RESOLVED 2026-04-12** — `resolveConfigPath()` now defaults to `~/.broker/config` and fallback `/etc/broker/config`; unit test added. Branch `fix/rebrand-runtime-doc-alignment`. | `cmd/awrit/init_cmd.go:53-64`, `cmd/awrit/init_cmd_test.go` |
 | TD-CLI-003 | **`docker-compose.yml` network still named `agentauth-net`** — docs say `agentwrit-net` after brand sweep | Low | Next compose-touching PR | `docker-compose.yml:35,42` |
-| TD-CI-002 | **Docker image build + push to Docker Hub** — `docker-build` CI gate builds the image and discards it; there is no release workflow that tags and publishes to a registry so operators can `docker pull agentwrit:latest` | **HIGH** | Before public release | `.github/workflows/` (new workflow), `docs/getting-started-operator.md`, `README.md` |
+| TD-CI-002 | ~~**Docker image build + push to Docker Hub**~~ | ~~HIGH~~ | **RESOLVED 2026-04-12** — `.github/workflows/release.yml` publishes multi-arch (amd64 + arm64) images to `devonartis/agentwrit` on push to `main` and on `v*` tags. Cosign keyless signing, SLSA provenance, SBOM attestation. Tags: `latest`, `main-<sha>`, `v<semver>`. Branch `fix/td-ci-002-dockerhub-publish`. | `.github/workflows/release.yml` (new), `Dockerfile`, `README.md`, `docs/getting-started-operator.md`, `docker-compose.yml` |
 | TD-CI-003 | **Automated `develop → main` PR workflow** — today develop → main is a direct strip-push with admin bypass. Should be a GHA that checks out main, merges develop, runs strip, opens a PR back to main, and the PR goes through all CI gates (main-hygiene included). Removes the "forgot to run strip" risk entirely. | **HIGH** | After TD-CI-002 | `.github/workflows/` (new workflow), potentially tighten branch protection on main to remove admin bypass |
-
-### TD-CI-002 Detail: Docker image publishing to Docker Hub
-
-**Current state:** `.github/workflows/ci.yml` has a `docker-build` job that runs `docker build -t agentwrit-ci:${{ github.sha }} .` on every PR and develop/main push. The image is built, verified to compile, then thrown away. No registry push.
-
-**Target state:** On push to `main` and on release tags, build the multi-arch (amd64 + arm64) image and push to **Docker Hub** as `devonartis/agentwrit:<tag>`. Tagging scheme:
-- `latest` — always tracks `main`
-- `main-<sha>` — every main push, for reproducibility
-- `v<semver>` — release tags (e.g. `v2.0.0`, `v2.0`, `v2`)
-- `develop` — optional, tracks `develop` branch for early adopters
-
-**Why Docker Hub (not GHCR):** operator UX. `docker pull devonartis/agentwrit` is the familiar path for most operators. GHCR is fine but adds a step (login / allow-list). Revisit if we move off Docker Hub for rate limit or licensing reasons.
-
-**What the workflow needs:**
-1. New `.github/workflows/release.yml` (or extend ci.yml) triggered on `push: [main]` and `push: { tags: [v*] }`
-2. `docker/login-action` with `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets
-3. `docker/setup-qemu-action` + `docker/setup-buildx-action` for multi-arch
-4. `docker/build-push-action` with `platforms: linux/amd64,linux/arm64` and appropriate tags
-5. Optional: SBOM + cosign signing for supply-chain integrity (already have syft; add cosign)
-
-**Docs that need updating once published:**
-- `README.md` — add `docker pull devonartis/agentwrit:latest` to Quick Start
-- `docs/getting-started-operator.md` — add a "Docker image" section with pull + run examples
-- `docs/getting-started-user.md` — mention pre-built image as an alternative to `git clone`
-- `CHANGELOG.md` — Added entry per release
-- `docker-compose.yml` — document how to use `image: devonartis/agentwrit:latest` instead of `build: .`
-
-**Secrets required:** `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` (scoped to the agentwrit repo only, not user-wide). Set via GitHub repo secrets.
-
-**Exit criteria:** `docker pull devonartis/agentwrit:latest && docker run devonartis/agentwrit` starts a broker with the documented env vars, passes the L2.5 smoke test when pointed at it, and the image has a valid SBOM and (optionally) a cosign signature.
 
 ### TD-CLI-002 Detail: awrit init config path mismatch — RESOLVED 2026-04-12
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,15 @@
 services:
   broker:
+    # Two ways to source the broker image:
+    #
+    #   1. LOCAL BUILD (default) — builds from this checkout. Use during
+    #      development or when hacking on broker code.
+    #   2. PRE-BUILT — pull the signed multi-arch image from Docker Hub.
+    #      To use, comment out the `build:` block below and uncomment the
+    #      `image:` line. Pin to a specific tag for production
+    #      (e.g. devonartis/agentwrit:v2.0.0 or devonartis/agentwrit:main-<sha>).
+    #
+    # image: devonartis/agentwrit:latest
     build:
       context: .
       target: broker
@@ -15,7 +25,7 @@ services:
       - AA_ADMIN_SECRET=${AA_ADMIN_SECRET:-}
       - AA_SEED_TOKENS=${AA_SEED_TOKENS:-false}
       - AA_LOG_LEVEL=${AA_LOG_LEVEL:-standard}
-      - AA_DB_PATH=${AA_DB_PATH:-/data/agentauth.db}
+      - AA_DB_PATH=${AA_DB_PATH:-/data/data.db}
       - AA_SIGNING_KEY_PATH=${AA_SIGNING_KEY_PATH:-/data/signing.key}
       - AA_CONFIG_PATH=${AA_CONFIG_PATH:-}
       - AA_TLS_MODE=${AA_TLS_MODE:-none}

--- a/docs/getting-started-operator.md
+++ b/docs/getting-started-operator.md
@@ -6,21 +6,104 @@ Deploy AgentWrit in production. This guide covers broker startup, TLS configurat
 
 ---
 
-## Quick Start (Docker Compose)
+## Deployment Options
 
-Get a broker running in three commands:
+There are three ways to deploy the broker, in order of how much you need to build locally:
+
+| Option | When to use |
+|---|---|
+| **1. Pre-built Docker Hub image** | Production, fastest onboarding, no source checkout needed. Multi-arch (amd64 + arm64), signed with cosign. |
+| **2. Docker Compose with local build** | You want to run unreleased code from `main` or `develop`, or you need to modify the Dockerfile. |
+| **3. Native binary (VPS mode)** | Systemd-managed deployments, bare-metal hosts, no Docker available. |
+
+---
+
+## Option 1: Pre-built image from Docker Hub
+
+The signed multi-arch broker image is published to [`devonartis/agentwrit`](https://hub.docker.com/r/devonartis/agentwrit) on every push to `main` and on release tags. This is the recommended operator onboarding path — no source checkout, no local build toolchain required.
+
+### Available tags
+
+| Tag | When it moves | Use for |
+|---|---|---|
+| `latest` | Every push to `main` | Quick evaluation, lab environments |
+| `main-<sha>` | Every push to `main` | Reproducible deployments, pinning to a specific commit |
+| `v2.0.0`, `v2.0`, `v2` | Release tags | **Production** — pin to an exact semver release |
+
+Never pin production to `latest` — it moves with every `main` push and can introduce unexpected changes. Pin to a `v<semver>` tag or a `main-<sha>` digest and upgrade on a schedule you control.
+
+### Pull and run
 
 ```bash
-# 1. Set the admin secret (required -- broker exits without it)
+# 1. Set the admin secret (required — broker exits without it)
 export AA_ADMIN_SECRET="$(openssl rand -hex 32)"
 
-# 2. Build and start the stack
+# 2. Pull a specific version (recommended over :latest for production)
+docker pull devonartis/agentwrit:v2.0.0
+
+# 3. Run with a persistent volume
+docker run -d --name agentwrit \
+  -p 8080:8080 \
+  -e AA_ADMIN_SECRET \
+  -e AA_BIND_ADDRESS=0.0.0.0 \
+  -e AA_DB_PATH=/data/data.db \
+  -e AA_SIGNING_KEY_PATH=/data/signing.key \
+  -v agentwrit-data:/data \
+  devonartis/agentwrit:v2.0.0
+
+# 4. Verify
+curl -s http://localhost:8080/v1/health | jq .
+```
+
+### Verifying the image signature
+
+The release workflow signs every published image with [cosign](https://github.com/sigstore/cosign) keyless mode, using a short-lived Sigstore certificate issued via GitHub Actions OIDC. There is no long-lived signing key to rotate. Verify before running in production:
+
+```bash
+cosign verify devonartis/agentwrit:v2.0.0 \
+  --certificate-identity-regexp='^https://github.com/devonartis/agentwrit/\.github/workflows/release\.yml@' \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+```
+
+If verification fails, **do not run the image** — it was not produced by this project's release pipeline. Report the discrepancy.
+
+### What's in the image
+
+- Multi-stage build (Alpine 3.21 runtime, ~12 MB compressed per arch)
+- Platforms: `linux/amd64`, `linux/arm64`
+- Binary: `/broker` (entry point)
+- Ports exposed: `8080`
+- OCI labels: `org.opencontainers.image.source`, `revision`, `created`, `title`, `description`, `licenses=AGPL-3.0-only`
+
+### Docker Hub listing
+
+- **Repository:** <https://hub.docker.com/r/devonartis/agentwrit>
+- **Source:** <https://github.com/devonartis/agentwrit>
+- **Issues and support:** <https://github.com/devonartis/agentwrit/issues>
+
+---
+
+## Option 2: Docker Compose (local build)
+
+If you're working from a source checkout — either to track unreleased changes or to modify the Dockerfile — use Docker Compose:
+
+```bash
+# 1. Clone the repo
+git clone https://github.com/devonartis/agentwrit.git
+cd agentwrit
+
+# 2. Set the admin secret (required -- broker exits without it)
+export AA_ADMIN_SECRET="$(openssl rand -hex 32)"
+
+# 3. Build and start the stack
 ./scripts/stack_up.sh
 
-# 3. Verify the broker is healthy
+# 4. Verify the broker is healthy
 curl http://localhost:8080/v1/health
 # {"status":"ok","version":"2.0.0","uptime":5,"db_connected":true,"audit_events_count":0}
 ```
+
+To swap the local build for the pre-built image without forking `docker-compose.yml`, edit the file and change `build: .` to `image: devonartis/agentwrit:v2.0.0` — the commented-out `image:` line at the top of the `broker:` service shows exactly where.
 
 To tear down the stack:
 


### PR DESCRIPTION
## Summary

Closes **TD-CI-002**. Ships a Docker Hub publishing workflow so operators can `docker pull devonartis/agentwrit` instead of cloning and building. Multi-arch (amd64 + arm64), cosign-signed, SLSA provenance, SBOM attestation.

## What's new

### `.github/workflows/release.yml`

| Setting | Value |
|---|---|
| Trigger | `push: main` + `push: tags: ['v*']` |
| Platforms | `linux/amd64` + `linux/arm64` (QEMU emulation on x86 runner) |
| Registry | Docker Hub — `devonartis/agentwrit` |
| Tags | `latest`, `main-<sha>`, `v<major>.<minor>.<patch>`, `v<major>.<minor>`, `v<major>` |
| Signing | cosign keyless (Sigstore + GitHub Actions OIDC) |
| Provenance | SLSA `mode=max` |
| SBOM | Attestation via `build-push-action` |
| Cache | `type=gha` for fast re-runs |
| Concurrency | `release-${{ github.ref }}`, `cancel-in-progress: false` (never kill a release mid-push) |

Pinned SHAs on every action (docker/setup-qemu@v4.0.0, docker/setup-buildx@v4.0.0, docker/login@v4.1.0, docker/metadata@v6.0.0, docker/build-push@v7.1.0, sigstore/cosign-installer@v4.1.1). Dependabot will rotate.

### `Dockerfile`

- OCI labels baked in at bake time (`org.opencontainers.image.{title,description,vendor,licenses,source,url,documentation}`) so `docker build .` locally produces a labeled image even without the release workflow
- `docker/metadata-action` overrides `revision`, `version`, `created` at publish time
- `go build` now uses `-trimpath` for reproducibility

### Docs

- **`README.md`** — new "Option A: Pre-built image from Docker Hub" in Quick Start, ahead of the clone-and-build path. Includes the full `docker run` example plus the `cosign verify` command
- **`docs/getting-started-operator.md`** — Quick Start restructured into three options (pre-built / local build / native binary). Pre-built is the new recommended path with OCI inventory and signature verification
- **`docker-compose.yml`** — commented-out `image: devonartis/agentwrit:latest` alongside `build: .` so operators can swap between them without restructuring. Also fixed stale `AA_DB_PATH` default (`agentauth.db` → `data.db`) missed by the earlier brand sweep
- **`CHANGELOG.md`** — Unreleased entry
- **`TECH-DEBT.md`** — TD-CI-002 marked RESOLVED

### `.gitignore` hardening

New patterns `*TOKEN*`, `*SECRET*`, `*CREDENTIAL*` block any future scratch-pad file with those words in its name from being committed. Prompted by a stray empty `DOCKER_INFO_TOKEN.md` that appeared during the Docker Hub setup — empty this time, but the pattern needs to exist before it's not.

## Manual setup required before first release

1. **Docker Hub repo** `devonartis/agentwrit` — ✓ created (public)
2. **Docker Hub PAT** scoped to read/write on `agentwrit` only — TODO (operator)
3. **GitHub repo secrets** `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` at https://github.com/devonartis/agentwrit/settings/secrets/actions — TODO (operator)

The workflow doesn't fire until push to `main` or a `v*` tag, so the secrets can land anytime before that — merging this PR by itself doesn't trigger a publish.

## Expected merge conflict

PR #13 (`fix/main-hygiene-gate`) adds TD-CI-002 as **pending**. This PR adds it as **RESOLVED**. Whichever PR lands first, the other needs a rebase + conflict resolution — keep the **RESOLVED** version.

## Test plan

- [ ] CI runs full pipeline on this PR against develop (release.yml is ignored because this PR doesn't target main)
- [ ] `gate-parity` passes (13 gates on both sides — release.yml is a separate workflow, not part of the CI gate list)
- [ ] `docker build -t agentwrit-test .` locally still succeeds (Dockerfile changes didn't break the build)
- [ ] `gofmt`, `vet`, `lint`, `contamination`, `brand-alignment` all still pass
- [ ] After merge to main, the `publish-dockerhub` job runs ONCE on the push to main, builds both archs, pushes to Docker Hub, signs with cosign. Verify with:
      ```bash
      docker pull devonartis/agentwrit:latest
      docker inspect devonartis/agentwrit:latest | jq '.[0].Config.Labels'
      cosign verify devonartis/agentwrit:latest \
        --certificate-identity-regexp='^https://github.com/devonartis/agentwrit/\.github/workflows/release\.yml@' \
        --certificate-oidc-issuer=https://token.actions.githubusercontent.com
      ```