### PR TITLE
docs: build-in-public banner + newcomer README rewrite + Decision 014 CONTRIBUTING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — README rewrite for newcomers + build-in-public banner (2026-04-12)
+
+- **`README.md`** — significant rewrite of the top section for people who are not already familiar with the product:
+  - Added a GitHub `[!IMPORTANT]` **build-in-public status banner** right under the badges: broker is stable, SDK and demo still landing, pin to `v<semver>` or `main-<sha>` for anything non-lab, issues welcome / external PRs paused.
+  - Replaced the jargon-heavy hero paragraph with a plain-English "What is AgentWrit?" section that leads with the writ metaphor — narrow authority, time-limited, revocable at the source.
+  - Added a new **"The problem AgentWrit solves"** section that frames the pain (long-lived API keys + prompt-injected agents = full blast radius) before introducing the solution.
+  - Rewrote the **Quick Start** as a 5-minute zero-to-first-agent-token walkthrough: Docker Hub pull → admin auth → launch token → Python SDK registration. Every step explains what the command does and why you're running it.
+  - Fixed 5 remaining prose references to `AgentAuth` missed in the earlier brand sweep.
+  - Updated Python SDK links from `github.com/devonartis/agentauth-python` → `github.com/devonartis/agentwrit-python` after the sister repo rename.
+
+### Changed — CONTRIBUTING.md policy rewrite (Decision 014, 2026-04-12)
+
+- **`CONTRIBUTING.md`** — restructured to match Decision 014 (build-in-public, external PRs paused):
+  - New top section "Contribution Policy (READ FIRST)" with a table of what's accepted (issues, security reports, feature requests) and what's not (external PRs of any kind). Explains why PRs are paused and lists 5-item exit criteria for reopening.
+  - Deleted the "Pull Request Process" section and PR checklist (misleading given the current policy).
+  - New "Filing a good Issue" section with concrete templates for bug reports and feature requests.
+  - New "If you're reading this to understand the code" section — preserves dev setup / code style / testing sections as valuable for readers who want to trace behavior without submitting code.
+  - Fixed `agentauth/` project tree root → `agentwrit/` and remaining prose brand references.
+
 ### Added — Docker Hub image publishing + cosign signing (TD-CI-002, 2026-04-12)
 
 - **`.github/workflows/release.yml`** — new workflow that publishes multi-arch (`linux/amd64` + `linux/arm64`) broker images to Docker Hub on every push to `main` and on `v*` release tags. Tags produced: `latest` (tracks main), `main-<sha>` (per-commit traceability), `v<major>.<minor>.<patch>` / `v<major>.<minor>` / `v<major>` (semver releases). Builds with buildx + QEMU emulation on the hosted x86 runner; cached via `type=gha` so repeat builds are fast.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,10 @@
-# Contributing to AgentAuth
+# Contributing to AgentWrit
 
-Thank you for your interest in contributing to AgentAuth. This guide covers everything you need to set up your environment, follow our standards, and submit contributions that can be reviewed and merged with confidence.
+Thank you for your interest in AgentWrit. **This project is in build-in-public mode and is not currently accepting external pull requests.** Bug reports, feature requests, and design feedback via GitHub Issues are very welcome. This guide explains what we *do* accept right now, what we don't, and what to expect if that changes.
 
 ## Table of Contents
 
+- [Contribution Policy (READ FIRST)](#contribution-policy-read-first)
 - [Code of Conduct](#code-of-conduct)
 - [License and CLA](#license-and-cla)
 - [Project Structure](#project-structure)
@@ -12,8 +13,32 @@ Thank you for your interest in contributing to AgentAuth. This guide covers ever
 - [Development Workflow](#development-workflow)
 - [Testing](#testing)
 - [Code Style](#code-style)
-- [Pull Request Process](#pull-request-process)
 - [Security Contributions](#security-contributions)
+
+## Contribution Policy (READ FIRST)
+
+**Current state: accepting Issues only. External Pull Requests are paused.**
+
+| Type of contribution | Status | How |
+|---|---|---|
+| **Bug reports** | ✅ Welcome | Open a GitHub Issue with reproducer steps, the image tag or commit SHA you were running, and the broker logs around the incident |
+| **Feature requests** | ✅ Welcome | Open a GitHub Issue explaining the use case and the problem you're trying to solve — not a proposed solution |
+| **Design feedback / discussion** | ✅ Welcome | GitHub Discussions (once enabled) or an Issue tagged `discussion` |
+| **Security vulnerabilities** | ✅ Welcome, private channel | See [SECURITY.md](SECURITY.md) — **do not** open a public Issue for vulnerabilities |
+| **Documentation typo / minor fix PRs** | ❌ Not accepting yet | File an Issue instead. The maintainer will make the edit. |
+| **Bug fix PRs** | ❌ Not accepting yet | File an Issue with the bug. Fix will land on a maintainer branch. |
+| **Feature PRs** | ❌ Not accepting yet | File an Issue with the use case. Feature design is discussed in the Issue before code is written. |
+
+**Why the PR pause:** AgentWrit is pre-1.0 and the contribution workflow (CLA automation, review bandwidth, test coverage for contributor-safety, commit-signing policy, PR template) hasn't been built out yet. Shipping a broken contributor experience is worse than shipping no contributor experience — we'd rather wait until the workflow is ready than accept PRs we can't review carefully.
+
+**When will PRs reopen?** When all of the following are true:
+1. CLA acceptance is automated (not a manual email exchange)
+2. The PR template exists and CI posts a comment with the relevant checklist
+3. There's a documented SLA for first-response on issues and PRs
+4. At least one non-maintainer has successfully used the contribution workflow end-to-end (as a dry run)
+5. Commit-signing is required and enforced for all PRs
+
+The [CHANGELOG](CHANGELOG.md) will announce the change when it happens, and this section will be updated. Until then, **please file issues rather than PRs**. Issues cost the maintainer ~1 minute of triage; an unreviewable PR costs hours of context reconstruction.
 
 ## Code of Conduct
 
@@ -21,16 +46,16 @@ This project and everyone participating in it is governed by our [Code of Conduc
 
 ## License and CLA
 
-The core AgentAuth server is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0)**. By contributing, you agree that your contributions will be licensed under AGPL-3.0.
+The core AgentWrit server is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0)**. Any code that does eventually land from external contributors will be licensed under AGPL-3.0.
 
-Substantial contributions (anything beyond typo fixes or minor doc corrections) require accepting the **[Contributor License Agreement](CLA.md)**. The CLA grants the project maintainer additional rights for commercial and enterprise use while you retain full ownership of your contributions. See `CLA.md` for the complete terms.
+Substantial contributions (anything beyond typo fixes or minor doc corrections) require accepting the **[Contributor License Agreement](CLA.md)**. The CLA grants the project maintainer additional rights for commercial and enterprise use while you retain full ownership of your contributions. See [`CLA.md`](CLA.md) for the complete terms.
 
-**We cannot merge non-trivial contributions unless the CLA has been accepted.**
+The CLA requirement is one of the things being automated before external PRs reopen (see the Contribution Policy above).
 
 ## Project Structure
 
 ```
-agentauth/
+agentwrit/
 ├── cmd/
 │   ├── broker/              # Credential broker HTTP server (main binary)
 │   └── awrit/               # Operator CLI — admin auth, app management, audit
@@ -366,50 +391,33 @@ log.Printf("Token %s validated for scope %s", tokenID, scope)
 - Security-sensitive events (auth failures, scope violations, revocations) must get audit entries
 - Security headers on all HTTP responses
 
-## Pull Request Process
+## Filing a good Issue
 
-1. **Ensure your branch is up to date** with `develop`:
+Since PRs are paused, the quality of your **issue report** is what lets the maintainer actually fix things. A good issue includes:
 
-   ```bash
-   git fetch origin
-   git rebase origin/develop
-   ```
+**For bug reports:**
+- **What you did** — exact commands, env vars, image tag or commit SHA (`docker pull devonartis/agentwrit:main-abc1234`)
+- **What you expected** — concrete, not "it should work"
+- **What actually happened** — error message verbatim, not paraphrased
+- **Broker logs** around the incident — `docker logs agentwrit 2>&1 | tail -100` or the equivalent
+- **Request ID** if the error was an HTTP response — broker emits `X-Request-ID` on every response, include it
+- **Environment** — OS, Docker version, deployment mode (Docker Hub image / source build / VPS binary)
 
-2. **Verify all quality gates pass:**
+**For feature requests:**
+- **The problem you're trying to solve** — what are you actually trying to accomplish?
+- **The workflow that doesn't work today** — specific steps, not generalizations
+- **Who else this affects** — only you, a team, a class of users, etc.
+- **Not:** a proposed implementation — that's for the maintainer to design after the problem is understood
 
-   ```bash
-   gofmt -l ./...                              # No output = clean
-   go vet ./...                                # No warnings
-   go test ./...                               # All pass
-   go build -o bin/broker ./cmd/broker/        # Broker builds
-   go build -o bin/awrit  ./cmd/awrit/         # CLI builds
-   ```
+**For security issues:** do NOT open a public Issue. See [SECURITY.md](SECURITY.md) for the private disclosure channel.
 
-3. **Submit your PR** against **`develop`** (not `main`) with:
+A well-written issue turns into a fix in minutes. A vague one bounces for days asking for the information above. If you're not sure what's needed, over-share — context is cheap to remove but expensive to guess.
 
-   - A clear title following commit message conventions
-   - Description of **what** changed and **why**
-   - Reference to the issue it addresses (e.g., "Fixes #42")
-   - Integration evidence for broker-facing changes (terminal output in PR description)
-   - Documentation updates if behavior changed
+## If you're reading this to understand the code, not contribute
 
-4. **CLA acceptance** — if this is your first substantial contribution, you will be asked to confirm that you accept the [CLA](CLA.md)
+The sections below (Prerequisites, Getting Started, Development Workflow, Testing, Code Style) are still here because **reading the code is a first-class use of this repo**. You can clone the repo, build it, run tests, trace behavior, and learn how ephemeral agent credentialing works without submitting any code back. That's explicitly supported — the AGPL-3.0 license guarantees it and the standards below exist so the code stays readable.
 
-5. **Code review** — all PRs require approval from at least one maintainer. Be responsive to feedback.
-
-### PR Checklist
-
-Before marking your PR as ready for review:
-
-- [ ] Code compiles (`go build ./...`)
-- [ ] All unit tests pass (`go test ./...`)
-- [ ] New code has unit tests (table-driven with subtests)
-- [ ] Integration evidence included for broker-facing changes
-- [ ] `gofmt` and `go vet` are clean
-- [ ] Comments explain who/why/boundaries (not what the code does)
-- [ ] No new dependencies without prior discussion
-- [ ] Documentation updated if behavior changed
-- [ ] Commit messages follow conventions
+When PRs reopen, these same sections will be the standard contributors are held to.
 - [ ] PR targets `develop`, not `main`
 - [ ] CLA accepted (first-time contributors)
 

--- a/README.md
+++ b/README.md
@@ -20,59 +20,150 @@ They're added now so the moment the repo flips public, they light up without
 needing a README update. Fire-and-forget.
 -->
 
-
-**Ephemeral agent credentialing for AI systems.**
-
-AgentAuth is a credential broker that issues short-lived, scope-attenuated tokens to AI agents. Each agent gets a unique [SPIFFE](https://spiffe.io/)-format identity and operates with only the permissions its task requires. Tokens are signed with Ed25519 (EdDSA), expire in minutes, and are revocable at four levels (token, agent, task, delegation chain). Every credential event is recorded in a tamper-evident audit trail.
-
-AgentAuth implements the [Ephemeral Agent Credentialing](https://github.com/devonartis/AI-Security-Blueprints/blob/main/patterns/ephemeral-agent-credentialing/versions/v1.3.md) security pattern — an 8-component architecture purpose-built for autonomous AI agents.
+> [!IMPORTANT]
+> **Building in public — pre-1.0.** The broker core is stable and we use it daily, but the Python SDK and demo app are still landing. Feel free to try it as we build in the open. For anything non-lab, pin to a `v<semver>` release or a `main-<sha>` image digest — `:latest` moves with every `main` commit and will change without notice. Issues are welcome; external PRs are paused until the contribution workflow is ready. See [CHANGELOG.md](CHANGELOG.md) for what shipped recently.
 
 ---
 
-## Why AgentAuth
+## What is AgentWrit?
 
-Traditional identity systems (OAuth, AWS IAM, service accounts) were designed for long-lived services with persistent identities. AI agents break those assumptions: they are ephemeral, non-deterministic, and require task-specific permissions at runtime. Giving an agent a static API key means it has every permission the key grants for as long as the key exists. AgentAuth replaces that model: agents get short-lived tokens scoped to exactly one task, and those tokens are revoked the moment the task completes.
+**AgentWrit gives AI agents temporary, task-scoped credentials instead of long-lived API keys.**
 
-Read more: [Concepts: Why AgentAuth Exists](docs/concepts.md)
+When an AI agent needs to do something — read a customer record, call a vendor API, run a query — it asks the AgentWrit broker for a token. The token works for that specific task, expires in minutes, and can be yanked at four different levels (token, agent, task, or entire delegation chain) the moment anything feels wrong. The agent never touches your long-lived credentials at all.
+
+Think of it as an issuer of legal **writs** for software: narrow authority, time-limited, revocable at the source, with a tamper-evident audit trail of every credential event.
+
+### The problem AgentWrit solves
+
+When you give an AI agent a long-lived API key, the agent can do anything the key allows, for as long as the key exists. If the agent misbehaves, leaks the key, hits a prompt-injection, or is repurposed for a task you didn't sanction — the blast radius is everything that key can touch. Rotation is a manual, dangerous operation. Revocation is instant to decide and slow to implement.
+
+AgentWrit inverts that model:
+
+- **Tokens are requested per task**, not issued in advance
+- **Scopes are narrow** — one task, one resource, one agent
+- **Lifetimes are short** — minutes, not years — with renewal via a fresh broker call
+- **Revocation is instant** at token, agent, task, or delegation-chain granularity
+- **Every issue / renew / revoke / delegate / release event is audited** in a tamper-evident hash chain
+
+The broker is the only component that holds your long-lived keys. Agents only ever see short-lived JWTs.
+
+AgentWrit implements the [Ephemeral Agent Credentialing v1.3](https://github.com/devonartis/AI-Security-Blueprints/blob/main/patterns/ephemeral-agent-credentialing/versions/v1.3.md) security pattern — an 8-component architecture built specifically for autonomous agents. Tokens are signed with Ed25519 (EdDSA), agents have [SPIFFE](https://spiffe.io/)-format identities, and the broker talks plain HTTP so you can put it behind whatever ingress you already run.
+
+More depth: [docs/concepts.md](docs/concepts.md).
 
 ---
 
-## Release Status
+## Release status
 
-**Current release:** v2.0.0 — MVP Prototype (pattern validation release)
-
-This release validates that AgentAuth is a working implementation of the target security pattern, ready for controlled demos, integration testing, and production hardening.
+**Current:** v2.0.0 — pattern validation release. The broker is stable, the full token lifecycle works, but the surrounding ecosystem (Python SDK, demo, TypeScript SDK) is still being built in public. See the banner at the top and [CHANGELOG.md](CHANGELOG.md) for current state.
 
 ---
 
-## Quick Start
+## Quick Start — five minutes from zero to first agent token
 
-Prerequisites: [Docker](https://docs.docker.com/get-docker/) (plus [Go 1.24+](https://go.dev/dl/) and [Docker Compose](https://docs.docker.com/compose/install/) for source builds).
+You're going to (1) start the broker, (2) authenticate as admin, (3) create a **launch token** (a one-shot registration credential), and (4) use that launch token to issue a scoped agent token. At the end you'll have a JWT your AI agent can hand to a resource server to prove it has permission for exactly one task.
+
+Prerequisites: [Docker](https://docs.docker.com/get-docker/). That's it for Option A. (Option B needs Docker Compose and a clone, Option C needs Go 1.24+.)
 
 ### Option A: Pre-built image from Docker Hub (fastest)
 
-The signed, multi-arch (`linux/amd64` + `linux/arm64`) broker image is published to Docker Hub on every push to `main` and on release tags. Pull and run directly — no clone required.
+The signed, multi-arch (`linux/amd64` + `linux/arm64`) broker image is published to Docker Hub on every push to `main` and on release tags. Pull and run directly — no git clone, no Go toolchain.
+
+**Step 1 — Set a strong admin secret and start the broker.**
 
 ```bash
-# 1. Set a strong admin secret (required — broker exits without it)
+# The broker exits on startup if AA_ADMIN_SECRET is unset. Use a real random value.
 export AA_ADMIN_SECRET="$(openssl rand -base64 32)"
 
-# 2. Pull and run
-docker run --rm -p 8080:8080 \
+docker run -d --name agentwrit \
+  -p 8080:8080 \
   -e AA_ADMIN_SECRET \
   -e AA_BIND_ADDRESS=0.0.0.0 \
-  -v agentwrit-data:/data \
   -e AA_DB_PATH=/data/data.db \
   -e AA_SIGNING_KEY_PATH=/data/signing.key \
+  -v agentwrit-data:/data \
   devonartis/agentwrit:latest
 
-# 3. In another terminal, verify health
+# Confirm it's up
 curl -s http://localhost:8080/v1/health | jq .
+# {"status":"ok","version":"2.0.0","uptime":3,"db_connected":true,"audit_events_count":0}
 ```
 
-Available tags: `latest` (always tracks `main`), `main-<sha>` (every commit), `v<major>.<minor>.<patch>` / `v<major>.<minor>` / `v<major>` (release tags).
+**What the env vars do:**
+- `AA_ADMIN_SECRET` — the root credential. Anyone who knows this can create launch tokens and revoke credentials. Treat like a root password.
+- `AA_BIND_ADDRESS=0.0.0.0` — inside the container, bind to all interfaces so Docker's port forwarding can reach it. (The default `127.0.0.1` is for VPS mode.)
+- `AA_DB_PATH` / `AA_SIGNING_KEY_PATH` — persist the SQLite audit log and the Ed25519 signing key to the named volume so they survive container restarts.
 
-**Verifying the image signature** (optional, recommended for production):
+**Step 2 — Authenticate as admin.**
+
+The admin secret isn't a bearer token — you exchange it for a short-lived admin JWT:
+
+```bash
+ADMIN_TOKEN=$(curl -s -X POST http://localhost:8080/v1/admin/auth \
+  -H "Content-Type: application/json" \
+  -d "{\"secret\":\"$AA_ADMIN_SECRET\"}" | jq -r '.access_token')
+
+echo "${ADMIN_TOKEN:0:20}..."  # should print "eyJhbGciOiJFZERTQSIs..."
+```
+
+**Step 3 — Create a launch token.**
+
+A launch token is a one-time registration credential. The agent presents it once (along with a signed challenge nonce) to get its real task-scoped JWT. You, the operator, decide what scopes the resulting agent is allowed to request:
+
+```bash
+LAUNCH_TOKEN=$(curl -s -X POST http://localhost:8080/v1/admin/launch-tokens \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_name": "demo-agent",
+    "orch_id": "quickstart",
+    "allowed_scope": ["read:data:*"],
+    "ttl_seconds": 300
+  }' | jq -r '.launch_token')
+
+echo "Launch token: ${LAUNCH_TOKEN:0:20}..."
+```
+
+**Step 4 — Register the agent and get a scoped JWT.**
+
+The agent generates an Ed25519 key pair, gets a nonce from the broker, signs it, and registers with the launch token plus the signed nonce. The broker verifies the signature, issues a SPIFFE identity, and returns a short-lived JWT scoped to `read:data:*`.
+
+The crypto here is enough code that the easy path is the Python SDK:
+
+```python
+from agentauth import AgentAuthApp
+
+# The SDK hides the challenge-response signing flow
+agent = AgentAuthApp(broker_url="http://localhost:8080").register(
+    launch_token=LAUNCH_TOKEN,
+    task_id="read-customer-42",
+    requested_scope=["read:data:customers:42"],  # must be subset of allowed_scope
+)
+
+# Now make a request to your resource server
+import httpx
+resp = httpx.get("https://your-api.example.com/customers/42",
+                 headers=agent.bearer_header)
+
+# When the task is done
+agent.release()
+```
+
+**Want to see the raw HTTP registration flow** (challenge + signed nonce + register) without the SDK? See [docs/getting-started-user.md](docs/getting-started-user.md) for the manual 6-step walkthrough with curl + openssl. Good for understanding what the SDK is doing under the hood.
+
+### Image tags and verification
+
+Available Docker Hub tags:
+
+| Tag | Moves | Use for |
+|---|---|---|
+| `latest` | Every `main` push | Lab and evaluation |
+| `main-<sha>` | Every `main` push | Reproducible deployments — pin to a specific commit |
+| `v<major>.<minor>.<patch>` / `v<major>.<minor>` / `v<major>` | Release tags | **Production** — pin to an exact semver release |
+
+Never pin production to `:latest`. Pin to a `v<semver>` or `main-<sha>` digest and upgrade on a schedule you control.
+
+**Verify the image signature** (optional, recommended for production):
 
 ```bash
 cosign verify devonartis/agentwrit:latest \
@@ -80,7 +171,7 @@ cosign verify devonartis/agentwrit:latest \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com
 ```
 
-Signed keyless with Sigstore via GitHub Actions OIDC — no long-lived signing key to rotate.
+Signed keyless with Sigstore via GitHub Actions OIDC — no long-lived signing key to rotate. If verification fails, **do not run the image** and report the discrepancy.
 
 ### Option B: Docker Compose (clone + build locally)
 
@@ -142,7 +233,7 @@ The typical workflow after setup is: create an app, issue a launch token for tha
 
 | Language | Repo | Install | Status |
 |----------|------|---------|--------|
-| **Python** | [agentauth-python](https://github.com/devonartis/agentauth-python) | `pip install agentauth` | v0.3.0 — 15 acceptance tests passing |
+| **Python** | [agentwrit-python](https://github.com/devonartis/agentwrit-python) | `pip install agentauth` *(PyPI rename pending)* | v0.3.0 — 15 acceptance tests passing |
 | **TypeScript** | Coming soon | — | Planned |
 
 The Python SDK wraps the broker's Ed25519 challenge-response flow into simple function calls:
@@ -168,13 +259,13 @@ response = httpx.get(url, headers=agent.bearer_header)
 agent.release()
 ```
 
-See the [Python SDK documentation](https://github.com/devonartis/agentauth-python) for the full API reference, delegation patterns, and error handling.
+See the [Python SDK documentation](https://github.com/devonartis/agentwrit-python) for the full API reference, delegation patterns, and error handling.
 
 ---
 
 ## See It In Action — MedAssist AI Demo
 
-The Python SDK includes **MedAssist AI**, an interactive healthcare demo that showcases every AgentAuth capability against a live broker.
+The Python SDK includes **MedAssist AI**, an interactive healthcare demo that showcases every AgentWrit capability against a live broker.
 
 A FastAPI web app where you enter a patient ID and a plain-language request. A local LLM chooses which tools to call. The app dynamically creates broker agents with only the scopes those tools need, for that specific patient. You see scope enforcement, cross-patient denial, delegation, token renewal, and release — all in a real-time execution trace.
 
@@ -187,13 +278,13 @@ A FastAPI web app where you enter a patient ID and a plain-language request. A l
 | **Token lifecycle** | Renewal and release shown at end of each encounter |
 | **Audit trail** | Dedicated audit tab showing hash-chained broker events |
 
-**Run it:** See the [MedAssist AI demo](https://github.com/devonartis/agentauth-python/tree/main/demo) in the Python SDK repo, including a [beginner's guide](https://github.com/devonartis/agentauth-python/blob/main/demo/BEGINNERS_GUIDE.md) with architecture diagrams and a [presenter's guide](https://github.com/devonartis/agentauth-python/blob/main/demo/PRESENTERS_GUIDE.md) for live demos.
+**Run it:** See the [MedAssist AI demo](https://github.com/devonartis/agentwrit-python/tree/main/demo) in the Python SDK repo, including a [beginner's guide](https://github.com/devonartis/agentwrit-python/blob/main/demo/BEGINNERS_GUIDE.md) with architecture diagrams and a [presenter's guide](https://github.com/devonartis/agentwrit-python/blob/main/demo/PRESENTERS_GUIDE.md) for live demos.
 
 ---
 
 ## Architecture
 
-AgentAuth is a single broker binary. Operators manage it with the `awrit` CLI. Developers and agents interact with it over HTTP.
+AgentWrit is a single broker binary. Operators manage it with the `awrit` CLI. Developers and agents interact with it over HTTP.
 
 ```mermaid
 flowchart TB
@@ -204,7 +295,7 @@ flowchart TB
         RS["Resource Servers"]
     end
 
-    subgraph AA["AgentAuth Broker :8080"]
+    subgraph AA["AgentWrit Broker :8080"]
         IDENTITY["Identity Service\nChallenge-response registration"]
         TOKEN["Token Service\nEdDSA JWT issue / verify / renew"]
         AUTHZ["Authz Middleware\nScope enforcement"]
@@ -392,7 +483,7 @@ The Docker Compose stack runs the broker on port 8080 (override with `AA_HOST_PO
 
 ## Operator CLI (awrit)
 
-`awrit` is the operator's command-line tool for managing the AgentAuth broker. It auto-authenticates with the broker using `AACTL_BROKER_URL` and `AACTL_ADMIN_SECRET`.
+`awrit` is the operator's command-line tool for managing the AgentWrit broker. It auto-authenticates with the broker using `AACTL_BROKER_URL` and `AACTL_ADMIN_SECRET`.
 
 ```bash
 # Build
@@ -505,7 +596,7 @@ server {
 
 | SDK | Description |
 |-----|-------------|
-| [Python SDK](https://github.com/devonartis/agentauth-python) | Full SDK with agent lifecycle, delegation, scope checking, and the MedAssist AI demo |
+| [Python SDK](https://github.com/devonartis/agentwrit-python) | Full SDK with agent lifecycle, delegation, scope checking, and the MedAssist AI demo |
 
 ### Guides
 
@@ -527,7 +618,7 @@ server {
 
 ## License
 
-AgentAuth is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0)**. See [LICENSE](LICENSE) for the full text.
+AgentWrit is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0)**. See [LICENSE](LICENSE) for the full text.
 
 Substantial contributions require accepting the [Contributor License Agreement](CLA.md). See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 


### PR DESCRIPTION
## Summary

Three coordinated docs changes to get the repo ready for public flip. All docs, no code, no behavior changes.

## 1. Build-in-public banner on README

New `[!IMPORTANT]` GitHub-native callout right under the badges:

> **Building in public — pre-1.0.** The broker core is stable and we use it daily, but the Python SDK and demo app are still landing. Feel free to try it as we build in the open. For anything non-lab, pin to a `v<semver>` release or a `main-<sha>` image digest — `:latest` moves with every `main` commit and will change without notice. Issues are welcome; external PRs are paused until the contribution workflow is ready.

## 2. README rewrite for newcomers

Problem: the old README assumed you already knew what "credential broker" and "scope-attenuated tokens" meant. Someone landing on the repo for the first time had no way to answer "what is this and why would I want it?"

What changed:

- **Plain-English hero** ("What is AgentWrit?") using the legal writ metaphor — narrow authority, time-limited, revocable at source
- **New "The problem AgentWrit solves" section** that frames the pain (long-lived API keys + prompt-injected agents = full blast radius) before introducing the solution
- **Rewrote Quick Start as a 5-minute end-to-end walkthrough**: Docker Hub pull → admin auth → launch token → Python SDK registration. Every step explains what the command does and why, not just shell lines to copy
- **Explained every `AA_*` env var inline** in the `docker run` example so first-timers understand the persistent volume isn't optional
- **Image tag guidance** — `latest` / `main-<sha>` / `v<semver>`, "never pin production to `:latest`" callout

Also fixed 5 remaining prose `AgentAuth` references missed in the earlier brand sweep. Python SDK code examples still say `from agentauth import` because the PyPI package rename is a separate cycle; README now notes "(PyPI rename pending)".

## 3. CONTRIBUTING.md rewrite for Decision 014

Old CONTRIBUTING still had a full "Pull Request Process" section with a PR checklist, directly contradicting Decision 014 (build-in-public, external PRs paused until the contribution workflow is ready).

What changed:

- **New "Contribution Policy (READ FIRST)" section** at top with a table showing what's accepted (issues, security reports, feature requests) and what isn't (external PRs of any kind). Explains **why** PRs are paused (CLA automation, PR template, review bandwidth, test coverage for contributor safety, commit signing — none ready) and lists **5 exit criteria** for reopening.
- **Deleted "Pull Request Process" and PR checklist** — misleading given current policy
- **New "Filing a good Issue"** section with concrete templates for bug reports and feature requests
- **New "If you're reading this to understand the code, not contribute"** section — preserves dev setup / code style / testing sections as valuable for readers who want to trace behavior or learn the pattern

## Test plan

- [ ] CI runs on this PR — all 14 gates green (docs-only, should be fast)
- [ ] `main-hygiene` shows as **skipping** (PR targets develop, not main — expected)
- [ ] Manually eyeball the rendered README on GitHub — banner renders as `[!IMPORTANT]` callout, headers make sense, code blocks formatted correctly
- [ ] Manually eyeball the rendered CONTRIBUTING.md — contribution policy table is clear

## Sequence

This PR is the last thing before flipping the repo public. After merge:

1. Strip-merge develop → main (banner + rewritten README land on main)
2. Second `main-hygiene` live run + another Docker Hub `release.yml` fire (publishes a new image with the rewritten README baked in via `org.opencontainers.image.documentation`)
3. Visual review of rendered main on github.com/devonartis/agentwrit
4. Flip repo visibility: `gh api -X PATCH /repos/devonartis/agentwrit --field visibility=public`
5. Re-enable GHAS-gated workflows (TD-VUL-005/006) as a small follow-up PR

All of those are separate steps with explicit confirmation points. This PR is just the docs.