### PR TITLE
fix: sweep stale agentauth refs missed in rebrand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — stale agentauth brand refs missed in rebrand (2026-04-13)
+
+- **`SECURITY.md`** — contact emails `security@agentauth.dev` → `security@agentwrit.com`; all "AgentAuth" brand references → "AgentWrit".
+- **`CODE_OF_CONDUCT.md`** — contact email `conduct@agentauth.dev` → `conduct@agentwrit.com`.
+- **`docs/scenarios.md`**, **`docs/agentwrit-explained.md`**, **`docs/README.md`**, **`docs/getting-started-developer.md`**, **`docs/getting-started-user.md`** — 11 Python SDK links still pointing to pre-rename `agentauth-python` → `agentwrit-python`.
+
 ### Changed — README rewrite for newcomers + build-in-public banner (2026-04-12)
 
 - **`README.md`** — significant rewrite of the top section for people who are not already familiar with the product:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **conduct@agentauth.dev** (replace with a monitored address if different). All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **conduct@agentwrit.com** (replace with a monitored address if different). All complaints will be reviewed and investigated promptly and fairly.
 
 Community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in AgentAuth, please report it responsibly to **security@agentauth.dev** rather than using public issue trackers.
+If you discover a security vulnerability in AgentWrit, please report it responsibly to **security@agentwrit.com** rather than using public issue trackers.
 
 **We ask that you:**
 - Provide detailed information about the vulnerability
@@ -43,13 +43,13 @@ The following items are **not** considered security vulnerabilities:
 - **Denial of Service against single-instance brokers**: The broker is designed to run as a single instance in trusted environments
 - **Issues requiring physical access**: Attacking the host system or underlying infrastructure
 - **Social engineering**: Techniques that manipulate users outside the system
-- **Client-side vulnerabilities**: Issues in applications using AgentAuth that don't stem from AgentAuth itself
+- **Client-side vulnerabilities**: Issues in applications using AgentWrit that don't stem from AgentWrit itself
 - **Configuration errors**: Improper deployment or configuration by operators
 - **Third-party dependency vulnerabilities**: These should be reported to the maintainers of those dependencies
 
 ## Security Design Principles
 
-AgentAuth is built on these core security principles:
+AgentWrit is built on these core security principles:
 
 1. **Short-Lived Tokens**: Authorization tokens have bounded lifetimes to limit exposure
 2. **Ed25519 Signatures**: All tokens are cryptographically signed using Ed25519
@@ -61,7 +61,7 @@ AgentAuth is built on these core security principles:
 
 ## Known Limitations
 
-Users should be aware of these limitations when deploying AgentAuth:
+Users should be aware of these limitations when deploying AgentWrit:
 
 - **Single Broker Instance**: The broker is designed as a single instance within a secure network. It does not support clustering or horizontal scaling. High availability requires load balancer failover.
 - **Signing Key Persistence**: The broker loads or creates an Ed25519 key at `AA_SIGNING_KEY_PATH` (default `./signing.key`). Persist this file across restarts so previously issued tokens remain valid; losing or rotating the key invalidates outstanding JWTs.
@@ -73,11 +73,11 @@ For tracked operational issues and tech debt, see the project issue tracker on G
 
 ## Threat Model
 
-For detailed information about AgentAuth's threat model, security assumptions, and architectural security considerations, see [docs/concepts.md](docs/concepts.md).
+For detailed information about AgentWrit's threat model, security assumptions, and architectural security considerations, see [docs/concepts.md](docs/concepts.md).
 
 ## Encrypted Communications
 
-For sensitive security correspondence, you may request a PGP key from **security@agentauth.dev** if you need end-to-end encrypted email.
+For sensitive security correspondence, you may request a PGP key from **security@agentwrit.com** if you need end-to-end encrypted email.
 
 ## Security Updates
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,12 +60,12 @@ Lookup documentation for endpoints, CLI commands, and internals.
 
 ## Live Demos
 
-See AgentWrit in action with the [Python SDK](https://github.com/devonartis/agentauth-python) demo applications:
+See AgentWrit in action with the [Python SDK](https://github.com/devonartis/agentwrit-python) demo applications:
 
 | Demo | What it shows |
 |------|-------------|
-| **[MedAssist AI](https://github.com/devonartis/agentauth-python/tree/main/demo)** | Healthcare multi-agent pipeline — clinical, prescription, and billing agents operating under strict scope isolation with LLM tool-calling, delegation, and per-patient scoping |
-| **[Support Ticket Zero-Trust](https://github.com/devonartis/agentauth-python/tree/main/demo2)** | Three LLM-driven agents processing support tickets with broker-issued scoped credentials, streaming execution via SSE, and natural token expiry |
+| **[MedAssist AI](https://github.com/devonartis/agentwrit-python/tree/main/demo)** | Healthcare multi-agent pipeline — clinical, prescription, and billing agents operating under strict scope isolation with LLM tool-calling, delegation, and per-patient scoping |
+| **[Support Ticket Zero-Trust](https://github.com/devonartis/agentwrit-python/tree/main/demo2)** | Three LLM-driven agents processing support tickets with broker-issued scoped credentials, streaming execution via SSE, and natural token expiry |
 
 Both demos run against a real AgentWrit broker and show the full credential lifecycle: agent registration, scope enforcement, delegation, renewal, release, and revocation.
 

--- a/docs/agentwrit-explained.md
+++ b/docs/agentwrit-explained.md
@@ -156,7 +156,7 @@ Ready to see it in action? Start here:
 **[Your First Five Minutes →](getting-started-user.md)**
 Run a local setup with Docker, walk through the registration flow, and get your first agent token.
 
-**[Live Demos →](https://github.com/devonartis/agentauth-python)**
+**[Live Demos →](https://github.com/devonartis/agentwrit-python)**
 See AgentWrit in real applications — a healthcare multi-agent pipeline and a support ticket zero-trust demo, both running against a live broker with LLM-driven agents.
 
 Or jump to the topic that matches your interest:

--- a/docs/getting-started-developer.md
+++ b/docs/getting-started-developer.md
@@ -26,7 +26,7 @@ The registration flow gives you full control over your keys. You manage the cryp
   - Python 3.8+ with `requests` and `cryptography`
   - Go 1.24+ with the standard library
 
-The [AgentWrit Python SDK](https://github.com/devonartis/agentauth-python) handles the full agent lifecycle. This guide covers the raw HTTP API for any language.
+The [AgentWrit Python SDK](https://github.com/devonartis/agentwrit-python) handles the full agent lifecycle. This guide covers the raw HTTP API for any language.
 
 ---
 

--- a/docs/getting-started-user.md
+++ b/docs/getting-started-user.md
@@ -355,8 +355,8 @@ If you're deploying AgentWrit in production:
 
 ### See It In a Real App
 Want to see AgentWrit in a full application instead of raw curl commands?
-- **[MedAssist AI Demo](https://github.com/devonartis/agentauth-python/tree/main/demo)** -- Healthcare multi-agent pipeline with LLM tool-calling, delegation, and per-patient scoping
-- **[Support Ticket Demo](https://github.com/devonartis/agentauth-python/tree/main/demo2)** -- Three agents processing support tickets with streaming execution and natural token expiry
+- **[MedAssist AI Demo](https://github.com/devonartis/agentwrit-python/tree/main/demo)** -- Healthcare multi-agent pipeline with LLM tool-calling, delegation, and per-patient scoping
+- **[Support Ticket Demo](https://github.com/devonartis/agentwrit-python/tree/main/demo2)** -- Three agents processing support tickets with streaming execution and natural token expiry
 
 ### For Everyone
 To deepen your understanding:

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -2,9 +2,9 @@
 
 These scenarios show how the Ephemeral Agent Credentialing components work together in production deployments with real API calls.
 
-**Want to run a real demo?** The [Python SDK](https://github.com/devonartis/agentauth-python) includes two working demo applications that implement these patterns against a live broker:
-- [MedAssist AI](https://github.com/devonartis/agentauth-python/tree/main/demo) — healthcare multi-agent pipeline with scope isolation, delegation, and LLM tool-calling
-- [Support Ticket Zero-Trust](https://github.com/devonartis/agentauth-python/tree/main/demo2) — three LLM-driven agents with streaming execution and natural token expiry
+**Want to run a real demo?** The [Python SDK](https://github.com/devonartis/agentwrit-python) includes two working demo applications that implement these patterns against a live broker:
+- [MedAssist AI](https://github.com/devonartis/agentwrit-python/tree/main/demo) — healthcare multi-agent pipeline with scope isolation, delegation, and LLM tool-calling
+- [Support Ticket Zero-Trust](https://github.com/devonartis/agentwrit-python/tree/main/demo2) — three LLM-driven agents with streaming execution and natural token expiry
 
 ---
 


### PR DESCRIPTION
## Summary
- SECURITY.md + CODE_OF_CONDUCT.md: `@agentauth.dev` emails → `@agentwrit.com`, "AgentAuth" → "AgentWrit"
- 5 docs files: `agentauth-python` repo links → `agentwrit-python` (11 occurrences)

## Test plan
- [x] `go test ./... -short` — all 15 packages pass
- [x] `gates.sh task` — build + vet pass
- [ ] CI gates green on PR