### PR TITLE
fix: clean diagrams — remove non-existent components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added — Architecture diagrams + splash pages (2026-04-13)
 
-- **`docs/diagrams/`** — 3 SVG architecture diagrams (architecture overview, token lifecycle, security topology) replacing the inline mermaid block. Built from code review, visual style adapted from agentauth-internal.
+- **`docs/diagrams/`** — 3 SVG architecture diagrams (architecture overview, token lifecycle, security topology) replacing the inline mermaid block. Built from code review — only components that exist in the codebase. No HITL, no resource server, no monitoring boxes.
 - **`docs/python-sdk.md`** — splash page for the Python SDK (private repo). Shows status, code sample, and links to raw HTTP alternative.
 - **`docs/demos.md`** — splash page for MedAssist AI and Support Ticket demos (ship with Python SDK).
 - **`README.md`** — added Ephemeral Agent Credentialing v1.3 pattern lineage in "How it works". All private-repo links now point to splash pages instead of 404s.

--- a/docs/diagrams/architecture-overview.svg
+++ b/docs/diagrams/architecture-overview.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="0 0 1200 850" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 1000 820" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <style>
-      .header-text { font-family: 'Segoe UI', 'Helvetica Neue', sans-serif; font-size: 16px; font-weight: 700; fill: white; }
-      .subtext { font-family: 'Segoe UI', 'Helvetica Neue', sans-serif; font-size: 12px; fill: #374151; }
-      .service-text { font-family: 'Segoe UI', 'Helvetica Neue', sans-serif; font-size: 11px; font-weight: 600; fill: white; text-anchor: middle; }
+      .header-text { font-family: 'Segoe UI', 'Helvetica Neue', sans-serif; font-weight: 700; fill: white; }
+      .service-text { font-family: 'Segoe UI', 'Helvetica Neue', sans-serif; font-size: 12px; font-weight: 600; fill: white; text-anchor: middle; }
       .label-text { font-family: 'Segoe UI', 'Helvetica Neue', sans-serif; font-size: 10px; fill: #1f2937; font-weight: 500; }
       .actor-text { font-family: 'Segoe UI', 'Helvetica Neue', sans-serif; font-size: 13px; font-weight: 600; fill: #1e3a5f; text-anchor: middle; }
+      .route-text { font-family: 'Consolas', 'Courier New', monospace; font-size: 9px; fill: #334155; }
     </style>
     <linearGradient id="grad-header" x1="0%" y1="0%" x2="100%" y2="0%">
       <stop offset="0%" style="stop-color:#1e3a5f" /><stop offset="100%" style="stop-color:#0f172a" />
@@ -35,283 +35,222 @@
     <filter id="shadow-bold" x="-50%" y="-50%" width="200%" height="200%">
       <feDropShadow dx="0" dy="4" stdDeviation="4" flood-opacity="0.25"/>
     </filter>
-    <marker id="arr-teal" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
-      <polygon points="0 0, 10 3, 0 6" fill="#0d9488" />
+    <marker id="arr" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#475569" />
     </marker>
-    <marker id="arr-emerald" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
-      <polygon points="0 0, 10 3, 0 6" fill="#059669" />
+    <marker id="arr-teal" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#0d9488" />
     </marker>
-    <marker id="arr-amber" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
-      <polygon points="0 0, 10 3, 0 6" fill="#d97706" />
+    <marker id="arr-amber" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#b45309" />
     </marker>
-    <marker id="arr-red" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
-      <polygon points="0 0, 10 3, 0 6" fill="#dc2626" />
-    </marker>
-    <marker id="arr-blue" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
-      <polygon points="0 0, 10 3, 0 6" fill="#1d4ed8" />
-    </marker>
-    <marker id="arr-purple" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
-      <polygon points="0 0, 10 3, 0 6" fill="#7c3aed" />
+    <marker id="arr-emerald" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#047857" />
     </marker>
   </defs>
 
-  <rect width="1200" height="850" fill="#f8fafc"/>
+  <rect width="1000" height="820" fill="#f8fafc"/>
 
   <!-- Header -->
-  <rect width="1200" height="60" fill="url(#grad-header)"/>
-  <text x="600" y="25" class="header-text" text-anchor="middle" font-size="24">AgentWrit Architecture Overview</text>
-  <text x="600" y="47" class="header-text" text-anchor="middle" font-size="12" opacity="0.8">Ephemeral Agent Credentialing — 10-Component Broker · Ed25519 · SPIFFE · Hash-Chain Audit</text>
+  <rect width="1000" height="55" fill="url(#grad-header)"/>
+  <text x="500" y="24" class="header-text" text-anchor="middle" font-size="22">AgentWrit Broker — Architecture</text>
+  <text x="500" y="44" class="header-text" text-anchor="middle" font-size="11" opacity="0.8">Single binary · 10 components · Ed25519 · SPIFFE · Hash-chain audit · 5 dependencies</text>
 
-  <!-- LAYER 1: EXTERNAL ACTORS -->
+  <!-- ═══ ACTORS ═══ -->
+
   <!-- Operator -->
   <g filter="url(#shadow)">
-    <rect x="80" y="80" width="160" height="100" rx="8" fill="#e0f2fe" stroke="#1e3a5f" stroke-width="2"/>
-    <circle cx="160" cy="110" r="18" fill="#1e3a5f"/>
-    <circle cx="153" cy="108" r="4" fill="#e0f2fe"/>
-    <path d="M 153 115 L 153 130 M 148 120 L 158 120" stroke="#e0f2fe" stroke-width="2" stroke-linecap="round"/>
-    <text x="160" y="158" class="actor-text">Operator</text>
-    <text x="160" y="173" class="label-text" text-anchor="middle">awrit CLI</text>
+    <rect x="50" y="75" width="200" height="90" rx="8" fill="#e0f2fe" stroke="#1e3a5f" stroke-width="2"/>
+    <text x="150" y="100" class="actor-text">Operator (awrit CLI)</text>
+    <text x="60" y="118" class="route-text">POST /v1/admin/auth → admin JWT</text>
+    <text x="60" y="131" class="route-text">POST /v1/admin/launch-tokens</text>
+    <text x="60" y="144" class="route-text">CRUD /v1/admin/apps · /v1/revoke</text>
+    <text x="60" y="157" class="route-text">GET  /v1/audit/events</text>
   </g>
 
-  <!-- Developer App -->
+  <!-- App -->
   <g filter="url(#shadow)">
-    <rect x="300" y="80" width="160" height="100" rx="8" fill="#f0fdf4" stroke="#059669" stroke-width="2"/>
-    <rect x="350" y="110" width="40" height="35" rx="3" fill="#059669"/>
-    <rect x="357" y="117" width="6" height="6" fill="#f0fdf4"/>
-    <rect x="366" y="117" width="6" height="6" fill="#f0fdf4"/>
-    <rect x="357" y="126" width="6" height="6" fill="#f0fdf4"/>
-    <rect x="366" y="126" width="6" height="6" fill="#f0fdf4"/>
-    <text x="380" y="158" class="actor-text">Developer</text>
-    <text x="380" y="173" class="label-text" text-anchor="middle">App (SDK)</text>
+    <rect x="400" y="75" width="200" height="90" rx="8" fill="#f0fdf4" stroke="#059669" stroke-width="2"/>
+    <text x="500" y="100" class="actor-text">App (SDK)</text>
+    <text x="410" y="118" class="route-text">POST /v1/app/auth → app JWT</text>
+    <text x="410" y="131" class="route-text">POST /v1/app/launch-tokens</text>
+    <text x="410" y="144" class="route-text">Scope bounded by ceiling</text>
   </g>
 
-  <!-- AI Agent -->
+  <!-- Agent -->
   <g filter="url(#shadow)">
-    <rect x="520" y="80" width="160" height="100" rx="8" fill="#fef3c7" stroke="#d97706" stroke-width="2"/>
-    <circle cx="600" cy="108" r="16" fill="#d97706"/>
-    <circle cx="595" cy="105" r="3" fill="#fef3c7"/>
-    <circle cx="605" cy="105" r="3" fill="#fef3c7"/>
-    <path d="M 600 115 L 600 130 M 595 120 L 605 120" stroke="#fef3c7" stroke-width="2" stroke-linecap="round"/>
-    <text x="600" y="158" class="actor-text">AI Agent</text>
-    <text x="600" y="173" class="label-text" text-anchor="middle">Ephemeral</text>
+    <rect x="750" y="75" width="200" height="90" rx="8" fill="#fef3c7" stroke="#b45309" stroke-width="2"/>
+    <text x="850" y="100" class="actor-text">AI Agent</text>
+    <text x="760" y="118" class="route-text">GET  /v1/challenge → nonce</text>
+    <text x="760" y="131" class="route-text">POST /v1/register → agent JWT</text>
+    <text x="760" y="144" class="route-text">POST /v1/token/renew · /release</text>
+    <text x="760" y="157" class="route-text">POST /v1/delegate</text>
   </g>
 
-  <!-- Resource Server -->
-  <g filter="url(#shadow)">
-    <rect x="740" y="80" width="160" height="100" rx="8" fill="#ede9fe" stroke="#7c3aed" stroke-width="2"/>
-    <rect x="785" y="105" width="50" height="40" rx="3" fill="#7c3aed"/>
-    <line x1="790" y1="115" x2="830" y2="115" stroke="#ede9fe" stroke-width="2"/>
-    <line x1="790" y1="125" x2="830" y2="125" stroke="#ede9fe" stroke-width="2"/>
-    <line x1="790" y1="135" x2="830" y2="135" stroke="#ede9fe" stroke-width="2"/>
-    <text x="820" y="158" class="actor-text">Resource</text>
-    <text x="820" y="173" class="label-text" text-anchor="middle">Server / API</text>
-  </g>
+  <!-- Actor arrows down to broker -->
+  <path d="M 150 165 L 150 210" stroke="#1e3a5f" stroke-width="2.5" marker-end="url(#arr)"/>
+  <path d="M 500 165 L 500 210" stroke="#047857" stroke-width="2.5" marker-end="url(#arr-emerald)"/>
+  <path d="M 850 165 L 850 210" stroke="#b45309" stroke-width="2.5" marker-end="url(#arr-amber)"/>
 
-  <!-- Monitoring -->
-  <g filter="url(#shadow)">
-    <rect x="960" y="80" width="160" height="100" rx="8" fill="#dbeafe" stroke="#1d4ed8" stroke-width="2"/>
-    <rect x="1005" y="105" width="50" height="40" rx="3" fill="#1d4ed8"/>
-    <circle cx="1015" cy="118" r="3" fill="#dbeafe"/>
-    <circle cx="1030" cy="118" r="3" fill="#dbeafe"/>
-    <circle cx="1045" cy="118" r="3" fill="#dbeafe"/>
-    <line x1="1010" y1="132" x2="1048" y2="132" stroke="#dbeafe" stroke-width="2"/>
-    <text x="1040" y="158" class="actor-text">Monitoring</text>
-    <text x="1040" y="173" class="label-text" text-anchor="middle">Prometheus</text>
-  </g>
-
-  <!-- Actor arrows -->
-  <path d="M 160 180 L 160 220" stroke="#1e3a5f" stroke-width="2" marker-end="url(#arr-teal)" stroke-dasharray="5,5"/>
-  <path d="M 380 180 L 380 220" stroke="#059669" stroke-width="2" marker-end="url(#arr-emerald)"/>
-  <path d="M 600 180 L 600 220" stroke="#d97706" stroke-width="2" marker-end="url(#arr-amber)"/>
-  <path d="M 820 180 L 820 220" stroke="#7c3aed" stroke-width="2" marker-end="url(#arr-purple)"/>
-  <path d="M 1040 180 L 1040 220" stroke="#1d4ed8" stroke-width="2" marker-end="url(#arr-blue)"/>
-
-  <!-- Flow labels -->
-  <text x="140" y="203" class="label-text" font-size="9" fill="#1e3a5f">admin API</text>
-  <text x="362" y="203" class="label-text" font-size="9" fill="#059669">app auth</text>
-  <text x="578" y="203" class="label-text" font-size="9" fill="#d97706">challenge</text>
-  <text x="802" y="203" class="label-text" font-size="9" fill="#7c3aed">validate</text>
-  <text x="1020" y="203" class="label-text" font-size="9" fill="#1d4ed8">/metrics</text>
-
-  <!-- LAYER 2: BROKER CORE -->
+  <!-- ═══ MIDDLEWARE ═══ -->
   <g filter="url(#shadow-bold)">
-    <rect x="60" y="225" width="1080" height="40" rx="6" fill="url(#grad-header)"/>
-    <text x="600" y="250" class="header-text" text-anchor="middle" font-size="14">AgentWrit Broker Core — Single Binary, 5 Dependencies</text>
+    <rect x="40" y="210" width="920" height="30" rx="6" fill="url(#grad-header)"/>
+    <text x="500" y="230" class="header-text" text-anchor="middle" font-size="11">RequestID → Logging → MaxBytesBody → Security Headers → Authz (Bearer + Scope)</text>
   </g>
 
-  <!-- Row 1: Identity, Token, App, Authz, Delegation -->
+  <!-- ═══ BROKER SERVICES ═══ -->
+
+  <!-- Row 1: The three entry-point services (one per actor) -->
+
+  <!-- Admin Service — handles Operator -->
   <g filter="url(#shadow)">
-    <rect x="70" y="285" width="195" height="100" rx="6" fill="url(#grad-teal)"/>
-    <text x="167" y="305" class="service-text">Identity Service</text>
-    <text x="167" y="320" class="label-text" text-anchor="middle" font-size="9" fill="#ecfdf5">Challenge-Response</text>
-    <text x="167" y="333" class="label-text" text-anchor="middle" font-size="9" fill="#ecfdf5">Ed25519 Verification</text>
-    <text x="167" y="346" class="label-text" text-anchor="middle" font-size="9" fill="#ecfdf5">SPIFFE ID Generation</text>
-    <text x="167" y="359" class="label-text" text-anchor="middle" font-size="9" fill="#ecfdf5">Launch Token Consume</text>
+    <rect x="50" y="260" width="260" height="95" rx="6" fill="url(#grad-blue)"/>
+    <text x="180" y="280" class="service-text">Admin Service</text>
+    <text x="180" y="296" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Bcrypt admin auth → admin JWT</text>
+    <text x="180" y="309" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Launch token create (hex, 30s TTL)</text>
+    <text x="180" y="322" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">App CRUD (register, list, update, delete)</text>
+    <text x="180" y="335" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Depends: Token, Store, Audit</text>
   </g>
 
+  <!-- App Service — handles App -->
   <g filter="url(#shadow)">
-    <rect x="275" y="285" width="195" height="100" rx="6" fill="url(#grad-emerald)"/>
-    <text x="372" y="305" class="service-text">Token Service</text>
-    <text x="372" y="320" class="label-text" text-anchor="middle" font-size="9" fill="#f0fdf4">EdDSA JWT Issuance</text>
-    <text x="372" y="333" class="label-text" text-anchor="middle" font-size="9" fill="#f0fdf4">Verify + Revocation Check</text>
-    <text x="372" y="346" class="label-text" text-anchor="middle" font-size="9" fill="#f0fdf4">Renewal (old revoked)</text>
-    <text x="372" y="359" class="label-text" text-anchor="middle" font-size="9" fill="#f0fdf4">MaxTTL Ceiling</text>
+    <rect x="370" y="260" width="260" height="95" rx="6" fill="url(#grad-emerald)"/>
+    <text x="500" y="280" class="service-text">App Service</text>
+    <text x="500" y="296" class="label-text" text-anchor="middle" font-size="9" fill="#f0fdf4">Client credential auth → app JWT</text>
+    <text x="500" y="309" class="label-text" text-anchor="middle" font-size="9" fill="#f0fdf4">App-scoped launch token create</text>
+    <text x="500" y="322" class="label-text" text-anchor="middle" font-size="9" fill="#f0fdf4">Scope ceiling enforcement</text>
+    <text x="500" y="335" class="label-text" text-anchor="middle" font-size="9" fill="#f0fdf4">Depends: Store, Token, Audit</text>
   </g>
 
+  <!-- Identity Service — handles Agent -->
   <g filter="url(#shadow)">
-    <rect x="480" y="285" width="195" height="100" rx="6" fill="url(#grad-amber)"/>
-    <text x="577" y="305" class="service-text">App Service</text>
-    <text x="577" y="320" class="label-text" text-anchor="middle" font-size="9" fill="#fffbeb">App Registration</text>
-    <text x="577" y="333" class="label-text" text-anchor="middle" font-size="9" fill="#fffbeb">Client Credential Auth</text>
-    <text x="577" y="346" class="label-text" text-anchor="middle" font-size="9" fill="#fffbeb">Scope Ceiling Enforce</text>
-    <text x="577" y="359" class="label-text" text-anchor="middle" font-size="9" fill="#fffbeb">Launch Token Create</text>
+    <rect x="690" y="260" width="260" height="95" rx="6" fill="url(#grad-teal)"/>
+    <text x="820" y="280" class="service-text">Identity Service</text>
+    <text x="820" y="296" class="label-text" text-anchor="middle" font-size="9" fill="#ecfdf5">Challenge nonce (30s TTL)</text>
+    <text x="820" y="309" class="label-text" text-anchor="middle" font-size="9" fill="#ecfdf5">Ed25519 signature verification</text>
+    <text x="820" y="322" class="label-text" text-anchor="middle" font-size="9" fill="#ecfdf5">SPIFFE ID assignment</text>
+    <text x="820" y="335" class="label-text" text-anchor="middle" font-size="9" fill="#ecfdf5">Depends: Store, Token, Audit</text>
   </g>
 
+  <!-- Arrows: entry services → core services -->
+  <path d="M 180 355 L 180 395" stroke="#1d4ed8" stroke-width="2" marker-end="url(#arr)"/>
+  <path d="M 500 355 L 500 395" stroke="#047857" stroke-width="2" marker-end="url(#arr-emerald)"/>
+  <path d="M 820 355 L 820 395" stroke="#0d9488" stroke-width="2" marker-end="url(#arr-teal)"/>
+
+  <!-- Cross-service arrows -->
+  <path d="M 310 310 L 370 310" stroke="#475569" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arr)"/>
+  <path d="M 630 310 L 690 310" stroke="#475569" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arr)"/>
+
+  <!-- Row 2: Core engine services -->
+
+  <!-- Token Service -->
   <g filter="url(#shadow)">
-    <rect x="685" y="285" width="195" height="100" rx="6" fill="url(#grad-blue)"/>
-    <text x="782" y="305" class="service-text">Authz Middleware</text>
-    <text x="782" y="320" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Bearer Token Validation</text>
-    <text x="782" y="333" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Scope Enforcement</text>
-    <text x="782" y="346" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Rate Limiting</text>
-    <text x="782" y="359" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Revocation Check</text>
+    <rect x="50" y="395" width="200" height="95" rx="6" fill="url(#grad-amber)"/>
+    <text x="150" y="415" class="service-text">Token Service</text>
+    <text x="150" y="431" class="label-text" text-anchor="middle" font-size="9" fill="#fffbeb">EdDSA JWT issue / verify / renew</text>
+    <text x="150" y="444" class="label-text" text-anchor="middle" font-size="9" fill="#fffbeb">Algorithm enforce (EdDSA only)</text>
+    <text x="150" y="457" class="label-text" text-anchor="middle" font-size="9" fill="#fffbeb">MaxTTL ceiling + KID matching</text>
+    <text x="150" y="470" class="label-text" text-anchor="middle" font-size="9" fill="#fffbeb">Depends: Keys, Config, Revoker</text>
   </g>
 
+  <!-- Authz Middleware -->
   <g filter="url(#shadow)">
-    <rect x="890" y="285" width="195" height="100" rx="6" fill="url(#grad-purple)"/>
-    <text x="987" y="305" class="service-text">Delegation Service</text>
-    <text x="987" y="320" class="label-text" text-anchor="middle" font-size="9" fill="#faf5ff">Scope Attenuation</text>
-    <text x="987" y="333" class="label-text" text-anchor="middle" font-size="9" fill="#faf5ff">Delegation Chains</text>
-    <text x="987" y="346" class="label-text" text-anchor="middle" font-size="9" fill="#faf5ff">Chain Verification</text>
-    <text x="987" y="359" class="label-text" text-anchor="middle" font-size="9" fill="#faf5ff">Child Token Issue</text>
+    <rect x="270" y="395" width="200" height="95" rx="6" fill="url(#grad-blue)"/>
+    <text x="370" y="415" class="service-text">Authz Middleware</text>
+    <text x="370" y="431" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Bearer token validation</text>
+    <text x="370" y="444" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Scope enforcement per route</text>
+    <text x="370" y="457" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Revocation check on every call</text>
+    <text x="370" y="470" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Depends: Token, Revoke, Audit</text>
   </g>
 
-  <!-- Row 2: Admin, Revocation, Audit, Observability, Store -->
+  <!-- Delegation Service -->
   <g filter="url(#shadow)">
-    <rect x="70" y="405" width="195" height="100" rx="6" fill="url(#grad-blue)"/>
-    <text x="167" y="425" class="service-text">Admin Service</text>
-    <text x="167" y="440" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Bcrypt Secret Auth</text>
-    <text x="167" y="453" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Admin JWT Issuance</text>
-    <text x="167" y="466" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Launch Token Mgmt</text>
-    <text x="167" y="479" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">App CRUD Routes</text>
+    <rect x="490" y="395" width="200" height="95" rx="6" fill="url(#grad-purple)"/>
+    <text x="590" y="415" class="service-text">Delegation Service</text>
+    <text x="590" y="431" class="label-text" text-anchor="middle" font-size="9" fill="#faf5ff">Scope attenuation only (↓)</text>
+    <text x="590" y="444" class="label-text" text-anchor="middle" font-size="9" fill="#faf5ff">Delegation chain tracking</text>
+    <text x="590" y="457" class="label-text" text-anchor="middle" font-size="9" fill="#faf5ff">Child token issue</text>
+    <text x="590" y="470" class="label-text" text-anchor="middle" font-size="9" fill="#faf5ff">Depends: Token, Store, Audit, Keys</text>
   </g>
 
+  <!-- Revocation Service -->
   <g filter="url(#shadow)">
-    <rect x="275" y="405" width="195" height="100" rx="6" fill="url(#grad-red)"/>
-    <text x="372" y="425" class="service-text">Revocation Service</text>
-    <text x="372" y="440" class="label-text" text-anchor="middle" font-size="9" fill="#fef2f2">Token Revocation</text>
-    <text x="372" y="453" class="label-text" text-anchor="middle" font-size="9" fill="#fef2f2">Agent Revocation</text>
-    <text x="372" y="466" class="label-text" text-anchor="middle" font-size="9" fill="#fef2f2">Task Revocation</text>
-    <text x="372" y="479" class="label-text" text-anchor="middle" font-size="9" fill="#fef2f2">Chain Revocation</text>
+    <rect x="710" y="395" width="240" height="95" rx="6" fill="url(#grad-red)"/>
+    <text x="830" y="415" class="service-text">Revocation Service</text>
+    <text x="830" y="431" class="label-text" text-anchor="middle" font-size="9" fill="#fef2f2">Level 1: Single token (by JTI)</text>
+    <text x="830" y="444" class="label-text" text-anchor="middle" font-size="9" fill="#fef2f2">Level 2: All tokens for agent</text>
+    <text x="830" y="457" class="label-text" text-anchor="middle" font-size="9" fill="#fef2f2">Level 3: All tokens for task</text>
+    <text x="830" y="470" class="label-text" text-anchor="middle" font-size="9" fill="#fef2f2">Level 4: Entire delegation chain</text>
   </g>
 
+  <!-- Row 2 → Row 3 arrows -->
+  <path d="M 150 490 L 150 530" stroke="#b45309" stroke-width="2" marker-end="url(#arr-amber)"/>
+  <path d="M 370 490 L 370 530" stroke="#1d4ed8" stroke-width="2" marker-end="url(#arr)"/>
+  <path d="M 590 490 L 590 530" stroke="#7c3aed" stroke-width="2" marker-end="url(#arr)"/>
+  <path d="M 830 490 L 830 530" stroke="#dc2626" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Horizontal links row 2 -->
+  <path d="M 250 440 L 270 440" stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+  <path d="M 470 440 L 490 440" stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+  <path d="M 690 440 L 710 440" stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Row 3: Foundation services -->
+
+  <!-- Audit Log -->
   <g filter="url(#shadow)">
-    <rect x="480" y="405" width="195" height="100" rx="6" fill="url(#grad-amber)"/>
-    <text x="577" y="425" class="service-text">Audit Log</text>
-    <text x="577" y="440" class="label-text" text-anchor="middle" font-size="9" fill="#fffbeb">SHA-256 Hash Chain</text>
-    <text x="577" y="453" class="label-text" text-anchor="middle" font-size="9" fill="#fffbeb">Tamper-Evident</text>
-    <text x="577" y="466" class="label-text" text-anchor="middle" font-size="9" fill="#fffbeb">24 Event Types</text>
-    <text x="577" y="479" class="label-text" text-anchor="middle" font-size="9" fill="#fffbeb">Queryable Trail</text>
+    <rect x="50" y="530" width="280" height="85" rx="6" fill="url(#grad-amber)"/>
+    <text x="190" y="550" class="service-text">Audit Log</text>
+    <text x="190" y="566" class="label-text" text-anchor="middle" font-size="9" fill="#fffbeb">SHA-256 hash chain — each entry hashes the previous</text>
+    <text x="190" y="579" class="label-text" text-anchor="middle" font-size="9" fill="#fffbeb">24 event types (auth, register, issue, revoke, delegate...)</text>
+    <text x="190" y="592" class="label-text" text-anchor="middle" font-size="9" fill="#fffbeb">Tamper-evident · Queryable by operator · Persistent</text>
   </g>
 
+  <!-- Keystore -->
   <g filter="url(#shadow)">
-    <rect x="685" y="405" width="195" height="100" rx="6" fill="url(#grad-teal)"/>
-    <text x="782" y="425" class="service-text">Observability</text>
-    <text x="782" y="440" class="label-text" text-anchor="middle" font-size="9" fill="#ecfdf5">Structured Logging</text>
-    <text x="782" y="453" class="label-text" text-anchor="middle" font-size="9" fill="#ecfdf5">4 Log Levels</text>
-    <text x="782" y="466" class="label-text" text-anchor="middle" font-size="9" fill="#ecfdf5">Prometheus Metrics</text>
-    <text x="782" y="479" class="label-text" text-anchor="middle" font-size="9" fill="#ecfdf5">Request Logging</text>
+    <rect x="360" y="530" width="200" height="85" rx="6" fill="url(#grad-teal)"/>
+    <text x="460" y="550" class="service-text">Keystore</text>
+    <text x="460" y="566" class="label-text" text-anchor="middle" font-size="9" fill="#ecfdf5">Ed25519 signing key</text>
+    <text x="460" y="579" class="label-text" text-anchor="middle" font-size="9" fill="#ecfdf5">Load from disk or generate</text>
+    <text x="460" y="592" class="label-text" text-anchor="middle" font-size="9" fill="#ecfdf5">Persists at AA_SIGNING_KEY_PATH</text>
   </g>
 
+  <!-- SQLite Store -->
   <g filter="url(#shadow)">
-    <rect x="890" y="405" width="195" height="100" rx="6" fill="url(#grad-blue)"/>
-    <text x="987" y="425" class="service-text">Store (SQLite)</text>
-    <text x="987" y="440" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Audit Events</text>
-    <text x="987" y="453" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Revocation Lists</text>
-    <text x="987" y="466" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">App Registry</text>
-    <text x="987" y="479" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Agents &amp; Nonces</text>
+    <rect x="590" y="530" width="360" height="85" rx="6" fill="url(#grad-blue)"/>
+    <text x="770" y="550" class="service-text">Store (SQLite)</text>
+    <text x="770" y="566" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Audit events · Revocation lists · App registry · Agent records · Nonces</text>
+    <text x="770" y="579" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">JTI pruning (60s interval) · Agent expiry (60s interval)</text>
+    <text x="770" y="592" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">Hash chain rebuilt from disk on startup · Persists at AA_DB_PATH</text>
   </g>
 
-  <!-- Internal connections row 1 → row 2 -->
-  <path d="M 167 385 L 167 405" stroke="#0d9488" stroke-width="2" marker-end="url(#arr-teal)"/>
-  <path d="M 372 385 L 372 405" stroke="#059669" stroke-width="2" marker-end="url(#arr-emerald)"/>
-  <path d="M 577 385 L 577 405" stroke="#d97706" stroke-width="2" marker-end="url(#arr-amber)"/>
-  <path d="M 782 385 L 782 405" stroke="#1d4ed8" stroke-width="2" marker-end="url(#arr-blue)"/>
-  <path d="M 987 385 L 987 405" stroke="#7c3aed" stroke-width="2" marker-end="url(#arr-purple)"/>
-
-  <!-- Horizontal connections -->
-  <path d="M 265 335 L 275 335" stroke="#0d9488" stroke-width="2" marker-end="url(#arr-teal)"/>
-  <path d="M 470 335 L 480 335" stroke="#059669" stroke-width="2" marker-end="url(#arr-emerald)"/>
-  <path d="M 675 335 L 685 335" stroke="#d97706" stroke-width="2" marker-end="url(#arr-amber)"/>
-  <path d="M 880 335 L 890 335" stroke="#1d4ed8" stroke-width="2" marker-end="url(#arr-blue)"/>
-  <path d="M 470 455 L 480 455" stroke="#dc2626" stroke-width="2" marker-end="url(#arr-red)"/>
-  <path d="M 675 455 L 685 455" stroke="#d97706" stroke-width="2" marker-end="url(#arr-amber)"/>
-  <path d="M 880 455 L 890 455" stroke="#0d9488" stroke-width="2" marker-end="url(#arr-teal)"/>
-
-  <!-- LAYER 3: MIDDLEWARE -->
-  <g filter="url(#shadow-bold)">
-    <rect x="60" y="535" width="1080" height="35" rx="6" fill="url(#grad-header)"/>
-    <text x="600" y="557" class="header-text" text-anchor="middle" font-size="13">HTTP Middleware Stack</text>
-  </g>
-
+  <!-- ═══ LEGEND ═══ -->
   <g filter="url(#shadow)">
-    <rect x="70" y="590" width="240" height="55" rx="6" fill="url(#grad-emerald)"/>
-    <text x="190" y="613" class="service-text">RequestID</text>
-    <text x="190" y="630" class="label-text" text-anchor="middle" font-size="9" fill="#f0fdf4">RFC 9457 trace correlation</text>
-  </g>
-  <g filter="url(#shadow)">
-    <rect x="330" y="590" width="240" height="55" rx="6" fill="url(#grad-teal)"/>
-    <text x="450" y="613" class="service-text">Logging</text>
-    <text x="450" y="630" class="label-text" text-anchor="middle" font-size="9" fill="#ecfdf5">Structured request/response</text>
-  </g>
-  <g filter="url(#shadow)">
-    <rect x="590" y="590" width="240" height="55" rx="6" fill="url(#grad-amber)"/>
-    <text x="710" y="613" class="service-text">MaxBytesBody</text>
-    <text x="710" y="630" class="label-text" text-anchor="middle" font-size="9" fill="#fffbeb">Request size limiting</text>
-  </g>
-  <g filter="url(#shadow)">
-    <rect x="850" y="590" width="240" height="55" rx="6" fill="url(#grad-blue)"/>
-    <text x="970" y="613" class="service-text">Security Headers</text>
-    <text x="970" y="630" class="label-text" text-anchor="middle" font-size="9" fill="#eff6ff">CSP, HSTS, X-Frame, etc.</text>
+    <rect x="40" y="645" width="920" height="80" rx="8" fill="white" stroke="#cbd5e1" stroke-width="1"/>
+    <text x="500" y="665" class="label-text" text-anchor="middle" font-size="11" font-weight="700" fill="#1e3a5f">Data Flow</text>
+
+    <line x1="60" y1="685" x2="100" y2="685" stroke="#1e3a5f" stroke-width="2.5" marker-end="url(#arr)"/>
+    <text x="110" y="690" class="label-text" font-size="10">Operator → Admin routes</text>
+
+    <line x1="330" y1="685" x2="370" y2="685" stroke="#047857" stroke-width="2.5" marker-end="url(#arr-emerald)"/>
+    <text x="380" y="690" class="label-text" font-size="10">App → Auth + launch tokens</text>
+
+    <line x1="610" y1="685" x2="650" y2="685" stroke="#b45309" stroke-width="2.5" marker-end="url(#arr-amber)"/>
+    <text x="660" y="690" class="label-text" font-size="10">Agent → Challenge + register + lifecycle</text>
+
+    <line x1="60" y1="710" x2="100" y2="710" stroke="#475569" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arr)"/>
+    <text x="110" y="715" class="label-text" font-size="10">Internal service dependency</text>
+
+    <text x="400" y="715" class="label-text" font-size="10" fill="#475569">All services write to Audit Log · All persistence via Store · All crypto via stdlib</text>
   </g>
 
-  <!-- Arrows between middleware -->
-  <path d="M 310 617 L 330 617" stroke="#059669" stroke-width="2" marker-end="url(#arr-emerald)"/>
-  <path d="M 570 617 L 590 617" stroke="#0d9488" stroke-width="2" marker-end="url(#arr-teal)"/>
-  <path d="M 830 617 L 850 617" stroke="#d97706" stroke-width="2" marker-end="url(#arr-amber)"/>
-
-  <!-- LEGEND -->
+  <!-- Story -->
   <g filter="url(#shadow)">
-    <rect x="60" y="680" width="1080" height="130" rx="8" fill="white" stroke="#cbd5e1" stroke-width="1"/>
-    <text x="600" y="702" class="label-text" text-anchor="middle" font-size="12" font-weight="700" fill="#1e3a5f">Key Flows &amp; Data Types</text>
-
-    <line x1="80" y1="730" x2="120" y2="730" stroke="#0d9488" stroke-width="2" marker-end="url(#arr-teal)"/>
-    <text x="135" y="735" class="label-text" font-size="10">Agent Registration &amp; Challenge-Response</text>
-
-    <line x1="450" y1="730" x2="490" y2="730" stroke="#059669" stroke-width="2" marker-end="url(#arr-emerald)"/>
-    <text x="505" y="735" class="label-text" font-size="10">Token Issuance &amp; Renewal</text>
-
-    <line x1="820" y1="730" x2="860" y2="730" stroke="#d97706" stroke-width="2" marker-end="url(#arr-amber)"/>
-    <text x="875" y="735" class="label-text" font-size="10">Audit &amp; Logging</text>
-
-    <line x1="80" y1="760" x2="120" y2="760" stroke="#dc2626" stroke-width="2" marker-end="url(#arr-red)"/>
-    <text x="135" y="765" class="label-text" font-size="10">Revocation &amp; Denial Flows</text>
-
-    <line x1="450" y1="760" x2="490" y2="760" stroke="#1d4ed8" stroke-width="2" marker-end="url(#arr-blue)"/>
-    <text x="505" y="765" class="label-text" font-size="10">Authorization &amp; Scope Enforcement</text>
-
-    <line x1="820" y1="760" x2="860" y2="760" stroke="#7c3aed" stroke-width="2" marker-end="url(#arr-purple)"/>
-    <text x="875" y="765" class="label-text" font-size="10">Delegation &amp; Scope Chains</text>
-
-    <text x="80" y="793" class="label-text" font-size="10" fill="#1e3a5f">Solid arrows: Primary flows</text>
-    <text x="380" y="793" class="label-text" font-size="10" fill="#1e3a5f">Dashed arrows: Operator/admin flows</text>
-    <text x="800" y="793" class="label-text" font-size="10" fill="#1e3a5f">All services: Go stdlib crypto only</text>
-  </g>
-
-  <!-- Story annotation -->
-  <g filter="url(#shadow)">
-    <rect x="60" y="820" width="1080" height="22" rx="4" fill="#ecfdf5" stroke="#059669" stroke-width="1"/>
-    <text x="600" y="835" class="label-text" text-anchor="middle" font-size="11" fill="#059669" font-weight="600">
-      Operator registers App → App authenticates → Issues launch token → Agent registers via Ed25519 challenge-response → Broker issues scoped JWT → Agent accesses Resource Server → Token expires or is revoked → All events hash-chain audited
+    <rect x="40" y="740" width="920" height="55" rx="6" fill="#ecfdf5" stroke="#059669" stroke-width="1"/>
+    <text x="500" y="760" class="label-text" text-anchor="middle" font-size="10" fill="#047857" font-weight="600">
+      Operator registers App (scope ceiling) → App authenticates (client creds) → App creates launch token (bounded by ceiling)
+    </text>
+    <text x="500" y="778" class="label-text" text-anchor="middle" font-size="10" fill="#047857" font-weight="600">
+      → Agent gets nonce → signs with Ed25519 → registers with launch token → receives scoped JWT → renew / delegate / release → all events hash-chain audited
     </text>
   </g>
 </svg>

--- a/docs/diagrams/security-topology.svg
+++ b/docs/diagrams/security-topology.svg
@@ -201,14 +201,9 @@
   <text x="970" y="710" class="component-text" fill="#4c1d95">Per-app override</text>
   <text x="970" y="730" class="component-text" fill="#4c1d95">Revocable at 4 levels</text>
 
-  <!-- Extension point callout -->
-  <rect x="60" y="790" width="1100" height="60" rx="10" fill="#fffbeb" stroke="#d97706" stroke-width="2"/>
-  <text x="600" y="815" text-anchor="middle" class="component-title" fill="#92400e">Extension Point: Enterprise Modules</text>
-  <text x="600" y="837" text-anchor="middle" class="component-text" fill="#78350f">HITL approval, OIDC provider, cloud credential exchange, and federation bridge plug into the broker via interfaces. Zero add-on code in this repo.</text>
-
   <!-- Legend -->
-  <text x="60" y="890" class="component-title" fill="#0f172a">Trust Model:</text>
-  <text x="220" y="890" class="component-text" fill="#334155">Zone 1 (Operator) controls scope ceilings, revocation, and audit.</text>
-  <text x="220" y="910" class="component-text" fill="#334155">Zone 2 (App) authenticates and creates launch tokens bounded by the ceiling.</text>
-  <text x="220" y="930" class="component-text" fill="#334155">Zone 3 (Agent) registers with Ed25519, receives scoped JWT, uses it at resource servers. No shared secrets.</text>
+  <text x="60" y="800" class="component-title" fill="#0f172a">Trust Model:</text>
+  <text x="220" y="800" class="component-text" fill="#334155">Zone 1 (Operator) controls scope ceilings, revocation, and audit.</text>
+  <text x="220" y="820" class="component-text" fill="#334155">Zone 2 (App) authenticates and creates launch tokens bounded by the ceiling.</text>
+  <text x="220" y="840" class="component-text" fill="#334155">Zone 3 (Agent) registers with Ed25519, receives scoped JWT. No shared secrets at the agent level.</text>
 </svg>

--- a/docs/diagrams/token-lifecycle.svg
+++ b/docs/diagrams/token-lifecycle.svg
@@ -72,8 +72,8 @@
   <text x="55" y="372" class="step-label" fill="#666">apps table (persisted)</text>
   <text x="55" y="389" class="step-label" fill="#666">audit: app_registered event</text>
   <text x="50" y="416" class="step-label" fill="#333">Lifetime: until deregistered</text>
-  <text x="50" y="440" class="step-label" fill="#333">No HITL — scope ceiling is the</text>
-  <text x="50" y="457" class="step-label" fill="#333">only policy gate for apps</text>
+  <text x="50" y="440" class="step-label" fill="#333">Scope ceiling is the policy</text>
+  <text x="50" y="457" class="step-label" fill="#333">gate for app launch tokens</text>
 
   <!-- Phase 2: App Auth (Teal) -->
   <rect x="300" y="20" width="270" height="260" rx="8" fill-opacity="0.08" fill="#0d5f63"/>
@@ -248,5 +248,5 @@
   <text x="460" y="730" class="legend-text" fill="#333">Registration (Agent)</text>
   <rect x="660" y="718" width="14" height="14" fill="url(#g-amber)" rx="2"/>
   <text x="680" y="730" class="legend-text" fill="#333">Lifecycle (Token States)</text>
-  <text x="920" y="730" class="legend-text" fill="#666">AgentWrit Core — No HITL gate in open-source core</text>
+  <text x="920" y="730" class="legend-text" fill="#666">AgentWrit Core — Open Source</text>
 </svg>

--- a/docs/python-sdk.md
+++ b/docs/python-sdk.md
@@ -1,6 +1,6 @@
 # AgentWrit Python SDK
 
-> **Coming soon.** The Python SDK is in active development and will be published as an open-source repo at [`devonartis/agentwrit-python`](https://github.com/devonartis/agentwrit-python) once it's ready.
+> **Coming soon to public.** The Python SDK is complete and will be published as an open-source repo at [`devonartis/agentwrit-python`](https://github.com/devonartis/agentwrit-python) after final cleanup.
 
 ## What it does
 


### PR DESCRIPTION
## Summary
- Architecture overview rebuilt: only 3 actors (Operator, App, Agent), real service deps from main.go
- Removed: Resource Server box, Prometheus/Monitoring box, enterprise extension callout, all HITL references
- Python SDK splash page updated: SDK is complete, pending cleanup (not "in development")

## Test plan
- [ ] CI gates green
- [ ] Visual review of rendered SVGs