### PR TITLE
fix: SPDX LicenseRef, gate enforcement, middleware diagram

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,14 +122,16 @@ jobs:
           echo "PASS: no stale brand strings"
       - name: SPDX header check
         run: |
-          MISSING=$(find cmd/ internal/ -name '*.go' -exec sh -c \
-            'head -1 "$1" | grep -qF "SPDX-License-Identifier:" || echo "$1"' _ {} \;)
-          if [ -n "$MISSING" ]; then
-            echo "FAIL: Go files missing SPDX-License-Identifier header:"
-            echo "$MISSING"
+          EXPECTED="// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0"
+          WRONG=$(find cmd/ internal/ -name '*.go' -exec sh -c \
+            'head -1 "$1" | grep -qxF "'"$EXPECTED"'" || echo "$1"' _ {} \;)
+          if [ -n "$WRONG" ]; then
+            echo "FAIL: Go files with missing or wrong SPDX header:"
+            echo "$WRONG"
+            echo "Expected first line: $EXPECTED"
             exit 1
           fi
-          echo "PASS: all Go files have SPDX headers"
+          echo "PASS: all Go files have correct SPDX header"
 
   unit-tests:
     name: unit-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — SPDX identifier + gate + middleware diagram (2026-04-13)
+
+- SPDX identifier corrected from `PolyForm-Internal-Use-1.0.0` to `LicenseRef-PolyForm-Internal-Use-1.0.0` across LICENSE and all 77 Go files. PolyForm Internal Use is not on the SPDX License List — `LicenseRef-` prefix is required by spec for unlisted licenses.
+- CI SPDX gate now checks the exact expected identifier, not just presence of `SPDX-License-Identifier:`.
+- Middleware stack diagram in `docs/architecture.md` corrected to match actual wrapping order in `cmd/broker/main.go`: `RequestID → Logging → MaxBytesBody → SecurityHeaders → mux`.
+
 ### Fixed — Architecture doc accuracy (2026-04-13)
 
 - Corrected SQLite version in External Dependencies table (v1.35.0 → v1.46.1).

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ AgentWrit — an authentication and credential broker for AI agents
 Copyright (c) 2024–2026 T. Devon Artis
 
 Licensed under the PolyForm Internal Use License 1.0.0.
-SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 Canonical text: https://polyformproject.org/licenses/internal-use/1.0.0
 
 -----------------------------------------------------------------------

--- a/cmd/awrit/apps.go
+++ b/cmd/awrit/apps.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package main — awrit app subcommands for managing registered apps.
 //

--- a/cmd/awrit/audit.go
+++ b/cmd/awrit/audit.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // audit.go implements the awrit audit command group.
 package main

--- a/cmd/awrit/client.go
+++ b/cmd/awrit/client.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package main
 

--- a/cmd/awrit/init_cmd.go
+++ b/cmd/awrit/init_cmd.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package main
 

--- a/cmd/awrit/init_cmd_test.go
+++ b/cmd/awrit/init_cmd_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package main
 

--- a/cmd/awrit/main.go
+++ b/cmd/awrit/main.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Command awrit is the operator CLI for the AgentAuth broker.
 package main

--- a/cmd/awrit/output.go
+++ b/cmd/awrit/output.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package main
 

--- a/cmd/awrit/revoke.go
+++ b/cmd/awrit/revoke.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Command awrit revoke subcommand — revokes tokens at various granularity levels.
 package main

--- a/cmd/awrit/root.go
+++ b/cmd/awrit/root.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package main
 

--- a/cmd/awrit/token.go
+++ b/cmd/awrit/token.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Command awrit token subcommand — token operations including release.
 package main

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Command broker starts the AgentAuth broker HTTP server.
 //

--- a/cmd/broker/serve.go
+++ b/cmd/broker/serve.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package main
 

--- a/cmd/broker/serve_test.go
+++ b/cmd/broker/serve_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package main
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -251,21 +251,21 @@ The broker applies two layers of middleware: global middleware on all requests, 
 flowchart LR
     REQ["HTTP\nRequest"] --> RID["RequestID\nMiddleware"]
     RID --> LOG["Logging\nMiddleware"]
-    LOG --> MUX["http.ServeMux\nRoute Match"]
-    MUX --> SEC["SecurityHeaders\n(global)"]
-    SEC --> MB["MaxBytesBody\n1 MB (global)"]
+    LOG --> MB["MaxBytesBody\n1 MB (global)"]
+    MB --> SEC["SecurityHeaders\n(global)"]
+    SEC --> MUX["http.ServeMux\nRoute Match"]
 
-    MB --> PUB["Public Handlers\n(health, challenge,\nmetrics, validate)"]
+    MUX --> PUB["Public Handlers\n(health, challenge,\nmetrics, validate)"]
 
-    MB --> AUTH_ONLY["ValMw.Wrap"] --> AUTH_H["Auth Handlers\n(renew, delegate,\nrelease)"]
+    MUX --> AUTH_ONLY["ValMw.Wrap"] --> AUTH_H["Auth Handlers\n(renew, delegate,\nrelease)"]
 
-    MB --> AUDIT_W["ValMw.Wrap"] --> AUDIT_C["ValMw\n.RequireScope"] --> AUDIT_H["Audit Handler\n(audit/events)"]
+    MUX --> AUDIT_W["ValMw.Wrap"] --> AUDIT_C["ValMw\n.RequireScope"] --> AUDIT_H["Audit Handler\n(audit/events)"]
 
-    MB --> SCOPE_W["ValMw.Wrap"] --> SCOPE_C["ValMw\n.RequireScope /\n.RequireAnyScope"] --> ADMIN_H["Scoped POST Handlers\n(revoke, launch-tokens,\nadmin/apps)"]
+    MUX --> SCOPE_W["ValMw.Wrap"] --> SCOPE_C["ValMw\n.RequireScope /\n.RequireAnyScope"] --> ADMIN_H["Scoped POST Handlers\n(revoke, launch-tokens,\nadmin/apps)"]
 
-    MB --> RL["RateLimiter\n.Wrap"] --> RL_H["Rate-Limited\n(admin/auth,\napp/auth)"]
+    MUX --> RL["RateLimiter\n.Wrap"] --> RL_H["Rate-Limited\n(admin/auth,\napp/auth)"]
 
-    MB --> REG_H["Register\n(launch token\nin body)"]
+    MUX --> REG_H["Register\n(launch token\nin body)"]
 ```
 
 **Route-to-middleware mapping from `cmd/broker/main.go`:**

--- a/internal/admin/admin_hdl.go
+++ b/internal/admin/admin_hdl.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package admin
 

--- a/internal/admin/admin_hdl_test.go
+++ b/internal/admin/admin_hdl_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package admin
 

--- a/internal/admin/admin_svc.go
+++ b/internal/admin/admin_svc.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package admin handles the operator side of the broker — authenticating
 // with the admin secret and managing launch tokens. The operator is the

--- a/internal/admin/admin_svc_test.go
+++ b/internal/admin/admin_svc_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package admin
 

--- a/internal/app/app_hdl.go
+++ b/internal/app/app_hdl.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package app — HTTP handlers for app CRUD (admin-operated) and app
 // authentication (self-service). The /v1/admin/apps/* routes are for the

--- a/internal/app/app_hdl_test.go
+++ b/internal/app/app_hdl_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package app
 

--- a/internal/app/app_svc.go
+++ b/internal/app/app_svc.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package app manages the app credential lifecycle. Apps are software that
 // manage agents — an orchestrator, a CI pipeline, a SaaS backend. Admin

--- a/internal/app/app_svc_test.go
+++ b/internal/app/app_svc_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package app
 

--- a/internal/audit/audit_log.go
+++ b/internal/audit/audit_log.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package audit provides a tamper-evident, hash-chain audit trail with
 // automatic PII sanitization.

--- a/internal/audit/audit_log_test.go
+++ b/internal/audit/audit_log_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package audit
 

--- a/internal/authz/rate_mw.go
+++ b/internal/authz/rate_mw.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // rate_mw.go — per-key token-bucket rate limiter. Protects admin auth
 // (per-IP) and app auth (per-client_id) against brute force and credential

--- a/internal/authz/rate_mw_test.go
+++ b/internal/authz/rate_mw_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package authz
 

--- a/internal/authz/scope.go
+++ b/internal/authz/scope.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package authz provides scope-based authorization and Bearer token
 // validation middleware for the AgentAuth broker.

--- a/internal/authz/scope_test.go
+++ b/internal/authz/scope_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package authz
 

--- a/internal/authz/val_mw.go
+++ b/internal/authz/val_mw.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package authz
 

--- a/internal/authz/val_mw_test.go
+++ b/internal/authz/val_mw_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package authz
 

--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package cfg loads broker configuration from AA_* environment variables.
 //

--- a/internal/cfg/cfg_test.go
+++ b/internal/cfg/cfg_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package cfg
 

--- a/internal/cfg/configfile.go
+++ b/internal/cfg/configfile.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package cfg
 

--- a/internal/cfg/configfile_test.go
+++ b/internal/cfg/configfile_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package cfg
 

--- a/internal/deleg/deleg_svc.go
+++ b/internal/deleg/deleg_svc.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package deleg provides scope-attenuated token delegation with chain
 // verification and depth limiting.

--- a/internal/deleg/deleg_svc_test.go
+++ b/internal/deleg/deleg_svc_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package deleg
 

--- a/internal/handler/audit_hdl.go
+++ b/internal/handler/audit_hdl.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler
 

--- a/internal/handler/challenge_hdl.go
+++ b/internal/handler/challenge_hdl.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler
 

--- a/internal/handler/deleg_hdl.go
+++ b/internal/handler/deleg_hdl.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler
 

--- a/internal/handler/doc.go
+++ b/internal/handler/doc.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package handler provides the HTTP layer for the broker. Handlers are thin —
 // they parse requests, call a domain service, and format responses. All

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler_test
 

--- a/internal/handler/health_hdl.go
+++ b/internal/handler/health_hdl.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler
 

--- a/internal/handler/logging.go
+++ b/internal/handler/logging.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler
 

--- a/internal/handler/logging_test.go
+++ b/internal/handler/logging_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler
 

--- a/internal/handler/metrics_hdl.go
+++ b/internal/handler/metrics_hdl.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler
 

--- a/internal/handler/reg_hdl.go
+++ b/internal/handler/reg_hdl.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler
 

--- a/internal/handler/release_hdl.go
+++ b/internal/handler/release_hdl.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler
 

--- a/internal/handler/release_hdl_test.go
+++ b/internal/handler/release_hdl_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler
 

--- a/internal/handler/renew_hdl.go
+++ b/internal/handler/renew_hdl.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler
 

--- a/internal/handler/request_id_test.go
+++ b/internal/handler/request_id_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler
 

--- a/internal/handler/revoke_hdl.go
+++ b/internal/handler/revoke_hdl.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler
 

--- a/internal/handler/security_hdl.go
+++ b/internal/handler/security_hdl.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler
 

--- a/internal/handler/security_hdl_test.go
+++ b/internal/handler/security_hdl_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler
 

--- a/internal/handler/val_hdl.go
+++ b/internal/handler/val_hdl.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package handler
 

--- a/internal/identity/id_svc.go
+++ b/internal/identity/id_svc.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package identity implements the agent registration flow including
 // challenge-response verification, SPIFFE ID generation, Ed25519 key

--- a/internal/identity/id_svc_test.go
+++ b/internal/identity/id_svc_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package identity
 

--- a/internal/identity/spiffe.go
+++ b/internal/identity/spiffe.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package identity
 

--- a/internal/keystore/keystore.go
+++ b/internal/keystore/keystore.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package keystore loads or generates an Ed25519 signing key pair,
 // persisting it to disk in PEM-encoded PKCS8 format.

--- a/internal/keystore/keystore_test.go
+++ b/internal/keystore/keystore_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package keystore
 

--- a/internal/mutauth/discovery.go
+++ b/internal/mutauth/discovery.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package mutauth
 

--- a/internal/mutauth/discovery_test.go
+++ b/internal/mutauth/discovery_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package mutauth
 

--- a/internal/mutauth/heartbeat.go
+++ b/internal/mutauth/heartbeat.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package mutauth
 

--- a/internal/mutauth/heartbeat_test.go
+++ b/internal/mutauth/heartbeat_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package mutauth
 

--- a/internal/mutauth/mut_auth_hdl.go
+++ b/internal/mutauth/mut_auth_hdl.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package mutauth provides agent-to-agent mutual authentication using a
 // three-step cryptographic handshake protocol.

--- a/internal/mutauth/mut_auth_hdl_test.go
+++ b/internal/mutauth/mut_auth_hdl_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package mutauth
 

--- a/internal/obs/obs.go
+++ b/internal/obs/obs.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package obs provides structured logging and Prometheus metrics for the
 // AgentAuth broker.

--- a/internal/problemdetails/problemdetails.go
+++ b/internal/problemdetails/problemdetails.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package problemdetails implements RFC 7807 "application/problem+json"
 // error responses and HTTP request infrastructure for the AgentWrit broker.

--- a/internal/revoke/rev_svc.go
+++ b/internal/revoke/rev_svc.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package revoke provides four-level token revocation for the AgentAuth
 // broker.

--- a/internal/revoke/rev_svc_test.go
+++ b/internal/revoke/rev_svc_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package revoke
 

--- a/internal/store/jti_test.go
+++ b/internal/store/jti_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package store
 

--- a/internal/store/sql_store.go
+++ b/internal/store/sql_store.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package store is the single persistence layer for the broker. It holds
 // everything: nonces (challenge-response), launch tokens (agent bootstrapping),

--- a/internal/store/sql_store_app_test.go
+++ b/internal/store/sql_store_app_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package store
 

--- a/internal/store/sql_store_revoke_test.go
+++ b/internal/store/sql_store_revoke_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package store
 

--- a/internal/store/sql_store_test.go
+++ b/internal/store/sql_store_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package store
 

--- a/internal/token/revoker.go
+++ b/internal/token/revoker.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package token
 

--- a/internal/token/tkn_claims.go
+++ b/internal/token/tkn_claims.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 // Package token implements EdDSA (Ed25519) JWT token issuance, verification,
 // and renewal for the AgentAuth broker.

--- a/internal/token/tkn_svc.go
+++ b/internal/token/tkn_svc.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package token
 

--- a/internal/token/tkn_svc_test.go
+++ b/internal/token/tkn_svc_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PolyForm-Internal-Use-1.0.0
+// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0
 
 package token
 

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -115,7 +115,7 @@ run_gate "format" bash -c 'test -z "$(gofmt -l .)"'
 # Brand alignment portion catches the gap that let obs.go metric names and
 # problemdetails.go URN namespace survive the first rebrand pass
 # (TD-RUNTIME-001 / TD-OBS-001).
-run_gate "contamination" bash -c "! grep -ri 'hitl\|approval\|oidc\|federation\|cloud\|sidecar' internal/ cmd/ 2>/dev/null && ! grep -rn 'urn:agentauth\|agentauth_\|github\.com/devonartis/agentauth[^-]' internal/ cmd/ --include='*.go' 2>/dev/null && ! find cmd/ internal/ -name '*.go' -exec sh -c 'head -1 \"\$1\" | grep -qF SPDX-License-Identifier: || echo \"\$1\"' _ {} \; | grep ."
+run_gate "contamination" bash -c "! grep -ri 'hitl\|approval\|oidc\|federation\|cloud\|sidecar' internal/ cmd/ 2>/dev/null && ! grep -rn 'urn:agentauth\|agentauth_\|github\.com/devonartis/agentauth[^-]' internal/ cmd/ --include='*.go' 2>/dev/null && ! find cmd/ internal/ -name '*.go' -exec sh -c 'head -1 \"\$1\" | grep -qxF \"// SPDX-License-Identifier: LicenseRef-PolyForm-Internal-Use-1.0.0\" || echo \"\$1\"' _ {} \; | grep ."
 
 run_gate "unit-tests" go test -short -count=1 ./...
 


### PR DESCRIPTION
## Summary

Fixes three findings from code review:

- **P2 — SPDX identifier**: `PolyForm-Internal-Use-1.0.0` is not on the SPDX License List. Changed to `LicenseRef-PolyForm-Internal-Use-1.0.0` across LICENSE + 77 Go files per SPDX spec for unlisted licenses.
- **P2 — Gate enforcement**: CI SPDX check now validates the exact expected identifier, not just presence of `SPDX-License-Identifier:`. Mirrored in `scripts/gates.sh`.
- **P3 — Middleware diagram**: Mermaid flowchart corrected to match `cmd/broker/main.go` wrapping order: `RequestID → Logging → MaxBytesBody → SecurityHeaders → mux`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -short` all packages pass
- [x] SPDX gate check passes locally with new exact-match logic
- [ ] CI gates-passed green