### PR TITLE
fix: nightly regression skips redundant task gates

### DIFF
--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -94,7 +94,15 @@ skip_gate() {
 # job AND with the linters-settings.gosec.excludes block in .golangci.yml.
 GOSEC_EXCLUDE="G117,G304,G101"
 
-# --- TASK gates ---
+# --- TASK gates (skipped in regression mode — CI already ran them on push) ---
+
+if [[ "$MODE" == "regression" ]]; then
+  echo ""
+  echo "=== Skipping task/full gates in regression mode ==="
+  echo "(CI gates run on every push; regression mode only runs test suites)"
+fi
+
+if [[ "$MODE" != "regression" ]]; then
 
 run_gate "build" go build ./cmd/broker ./cmd/awrit
 
@@ -191,6 +199,8 @@ if [[ "$MODE" == "full" ]]; then
     exit 0
   '
 fi
+
+fi  # end of MODE != regression
 
 # --- REGRESSION gates (only if mode is regression) ---
 


### PR DESCRIPTION
## Summary

Nightly regression failed every night (#9, #10, #16) because `gates.sh regression` ran all task gates before the regression loop. `golangci-lint` wasn't installed on the nightly runner → immediate exit.

Fix: regression mode now skips directly to the regression test loop. CI already runs all task/full gates on every push — running them again nightly is redundant.

Closes #9, #10, #16.

## Test plan

- [x] `./scripts/gates.sh task` still runs task gates
- [x] `./scripts/gates.sh regression` skips to regression loop
- [ ] CI gates-passed green