### PR TITLE
docs: diagram page links + Python SDK live

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ AgentWrit implements the [Ephemeral Agent Credentialing v1.3](https://github.com
   <img src="docs/diagrams/architecture-overview.svg" alt="AgentWrit Architecture Overview" width="100%">
 </p>
 
-> **Detailed diagrams:** [Token Lifecycle](docs/diagrams/token-lifecycle.svg) · [Security Topology](docs/diagrams/security-topology.svg)
+> **Detailed diagrams:** [Token Lifecycle](docs/token-lifecycle.md) · [Security Topology](docs/security-topology.md)
 
 1. **Operator** creates a launch token with an allowed scope ceiling
 2. **App** hands the launch token to the agent for a specific task

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,8 @@ Lookup documentation for endpoints, CLI commands, and internals.
 | [API Reference](api.md) | All 19 HTTP endpoints — request/response formats, error codes, rate limits |
 | [CLI Reference (awrit)](awrit-reference.md) | Every `awrit` command with examples and output formats |
 | [Architecture](architecture.md) | Internal package map, component diagrams, data flow |
+| [Token Lifecycle](token-lifecycle.md) | Diagram and walkthrough — issuance, renewal, delegation, revocation, release, expiration |
+| [Security Topology](security-topology.md) | Diagram and walkthrough — three trust zones, scope attenuation chain, security properties |
 | [Implementation Map](implementation-map.md) | Where every feature lives in the codebase — file paths, function names, test locations |
 | [Concepts Deep Dive](concepts.md) | The full security pattern, industry context, and all eight components |
 

--- a/docs/python-sdk.md
+++ b/docs/python-sdk.md
@@ -1,15 +1,15 @@
 # AgentWrit Python SDK
 
-> **Coming soon to public.** The Python SDK is complete and will be published at [`devonartis/agentwrit-python`](https://github.com/devonartis/agentwrit-python) after final cleanup.
+The Python SDK is live on [PyPI](https://pypi.org/project/agentwrit/) and [GitHub](https://github.com/devonartis/agentwrit-python).
 
 ## What it does
 
 The Python SDK wraps the broker's Ed25519 challenge-response registration flow into simple function calls. You don't need to manage nonces, signatures, or token renewal manually.
 
 ```python
-from agentauth import AgentAuthApp
+from agentwrit import AgentWritApp
 
-agent = AgentAuthApp(broker_url="http://localhost:8080").register(
+agent = AgentWritApp(broker_url="http://localhost:8080").register(
     launch_token=LAUNCH_TOKEN,
     task_id="read-customer-42",
     requested_scope=["read:data:customers:42"],
@@ -22,17 +22,29 @@ response = httpx.get(url, headers=agent.bearer_header)
 agent.release()
 ```
 
+## Install
+
+```bash
+pip install agentwrit
+```
+
 ## Current status
 
-- **v0.3.0** — 15 acceptance tests passing against a live broker
 - Full agent lifecycle: register, renew, delegate, release
 - Scope checking and validation helpers
-- `pip install agentauth` *(PyPI rename to `agentwrit` pending)*
+- 11 CI gates including bandit and pip-audit
+- Live demos: MedAssist AI healthcare pipeline, Support Ticket zero-trust agents
 
-## In the meantime
+## Demos
 
-You can use the broker's HTTP API directly from any language. See the [Getting Started walkthrough](getting-started-user.md) for the full curl-based registration flow, or the [API Reference](api.md) for all endpoints.
+See [Live Demos](demos.md) for working examples that run against a real broker — including multi-agent LLM pipelines with scope isolation, delegation, and per-patient scoping.
 
-## Get notified
+## Links
 
-Watch this repo or [file an issue](https://github.com/devonartis/agentwrit/issues) to be notified when the SDK goes public.
+- **PyPI:** [pypi.org/project/agentwrit](https://pypi.org/project/agentwrit/)
+- **GitHub:** [devonartis/agentwrit-python](https://github.com/devonartis/agentwrit-python)
+- **Docker Hub:** [devonartis/agentwrit-medassist](https://hub.docker.com/r/devonartis/agentwrit-medassist) (MedAssist demo)
+
+## Using the broker directly
+
+You can also use the broker's HTTP API directly from any language. See the [Getting Started walkthrough](getting-started-user.md) for the full curl-based registration flow, or the [API Reference](api.md) for all endpoints.


### PR DESCRIPTION
## Summary
- README diagram links point to markdown pages (token-lifecycle.md, security-topology.md) instead of raw SVGs
- docs/README.md adds diagram pages to Reference table
- docs/python-sdk.md updated — SDK is live on PyPI, removed "coming soon" banner

## Test plan
- [ ] Verify diagram links in README render correctly on GitHub
- [ ] Verify docs/README.md table entries link to correct pages
- [ ] Verify python-sdk.md links to PyPI and GitHub are correct