### PR TITLE
docs: update README banner — SDK and demos landed

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 [![SPIFFE](https://img.shields.io/badge/Identity-SPIFFE-0F9D58)](https://spiffe.io/)
 
 > [!IMPORTANT]
-> **Building in public.** The broker core is stable and we use it daily, but the Python SDK and demo app are still landing. For anything non-lab, pin to a versioned tag like `v2.0.0` or a commit-pinned digest like `main-899e4ca3` — `:latest` moves with every `main` commit and will change without notice. Issues are welcome; external PRs are paused until the contribution workflow is ready. See [CHANGELOG.md](CHANGELOG.md) for what shipped recently.
+> **Building in public.** The broker core and [Python SDK](https://github.com/devonartis/agentwrit-python) are stable and in daily use. For anything non-lab, pin to a versioned tag like `v2.0.0` or a commit-pinned digest like `main-899e4ca3` — `:latest` moves with every `main` commit and will change without notice. Issues are welcome; external PRs are paused until the contribution workflow is ready. See [CHANGELOG.md](CHANGELOG.md) for what shipped recently.
 
 ---
 


### PR DESCRIPTION
## Summary
- Python SDK repo (`agentwrit-python`) is public with src, tests, and two demos
- Banner no longer claims they're "still landing"
- Links SDK repo directly from the banner

## Test plan
- [ ] Banner renders correctly with SDK link on GitHub