### PR TITLE
chore(gitignore): also ignore /.plan/ (Decision 019 gap)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ __pycache__/
 /COWORK_DOCS_AUDIT.md
 /.active_module
 /.plans/
+/.plan/
 /adr/
 /audit/
 


### PR DESCRIPTION
`/.plans/` was already ignored, but the singular `/.plan/` variant slipped past the rule — letting dev-internal planning artifacts land in the public repo (Decision 019 gap, surfaced in the 2026-05-28 agentwrit-ent removal). This blocks both.

One-line `.gitignore` change. Docs/chore only.